### PR TITLE
Add support for floats

### DIFF
--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1233,8 +1233,6 @@ def bencode(obj: object) -> bytes:
     assert not isinstance(obj, bool)
     if isinstance(obj, int):
         return b"i" + str(int(obj)).encode("ascii") + b"e"
-    if isinstance(obj, float):
-        return b"f" + str(float(obj)).encode("ascii") + b"e"
     if isinstance(obj, bytes):
         return str(len(obj)).encode("ascii") + b":" + obj
     if isinstance(obj, list):

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -217,6 +217,8 @@ class Lexer:
         while self.has_input():
             c = self.peek_char()
             if c == ".":
+                if has_decimal:
+                    raise ParseError(f"unexpected token {c!r}")
                 has_decimal = True
             elif not c.isdigit():
                 break
@@ -1333,6 +1335,17 @@ class TokenizerTests(unittest.TestCase):
 
     def test_tokenize_negative_float(self) -> None:
         self.assertEqual(tokenize("-3.14"), [Operator("-"), FloatLit(3.14)])
+
+    @unittest.skip("TODO: support floats with no integer part")
+    def test_tokenize_float_with_no_integer_part(self) -> None:
+        self.assertEqual(tokenize(".14"), [FloatLit(0.14)])
+
+    def test_tokenize_float_with_no_decimal_part(self) -> None:
+        self.assertEqual(tokenize("10."), [FloatLit(10.0)])
+
+    def test_tokenize_float_with_multiple_decimal_points_raises_parse_error(self) -> None:
+        with self.assertRaisesRegex(ParseError, re.escape("unexpected token '.'")):
+            tokenize("1.0.1")
 
     def test_tokenize_binop(self) -> None:
         self.assertEqual(tokenize("1 + 2"), [IntLit(1), Operator("+"), IntLit(2)])

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1081,7 +1081,7 @@ def match(obj: Object, pattern: Object) -> Optional[Env]:
     if isinstance(pattern, Int):
         return {} if isinstance(obj, Int) and obj.value == pattern.value else None
     if isinstance(pattern, Float):
-        return {} if isinstance(obj, Float) and obj.value == pattern.value else None
+        raise MatchError("pattern matching is not supported for Floats")
     if isinstance(pattern, String):
         return {} if isinstance(obj, String) and obj.value == pattern.value else None
     if isinstance(pattern, Var):
@@ -2190,14 +2190,17 @@ class MatchTests(unittest.TestCase):
     def test_match_int_with_non_int_returns_none(self) -> None:
         self.assertEqual(match(String("abc"), pattern=Int(1)), None)
 
-    def test_match_with_equal_floats_returns_empty_dict(self) -> None:
-        self.assertEqual(match(Float(1), pattern=Float(1)), {})
+    def test_match_with_equal_floats_raises_match_error(self) -> None:
+        with self.assertRaisesRegex(MatchError, re.escape("pattern matching is not supported for Floats")):
+            match(Float(1), pattern=Float(1))
 
-    def test_match_with_inequal_floats_returns_none(self) -> None:
-        self.assertEqual(match(Float(2), pattern=Float(1)), None)
+    def test_match_with_inequal_floats_raises_match_error(self) -> None:
+        with self.assertRaisesRegex(MatchError, re.escape("pattern matching is not supported for Floats")):
+            match(Float(2), pattern=Float(1))
 
-    def test_match_float_with_non_float_returns_none(self) -> None:
-        self.assertEqual(match(String("abc"), pattern=Float(1)), None)
+    def test_match_float_with_non_float_raises_match_error(self) -> None:
+        with self.assertRaisesRegex(MatchError, re.escape("pattern matching is not supported for Floats")):
+            match(String("abc"), pattern=Float(1))
 
     def test_match_with_equal_strings_returns_empty_dict(self) -> None:
         self.assertEqual(match(String("a"), pattern=String("a")), {})

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -179,7 +179,7 @@ class Lexer:
                 return self.read_bytes()
             raise ParseError(f"unexpected token {c!r}")
         if c.isdigit():
-            return self.read_integer(c)
+            return self.read_number(c)
         if c in "()[]{}":
             custom = {
                 "(": LeftParen,


### PR DESCRIPTION
- Add `FloatLit`
- Update `Lexer` to support tokenizing numbers with decimal parts
- Add `Float` object
- Update `Parser` to parse `FloatLit` into `Float`
- Update arithmetic binops to work for both `Int` and `Float`
- Add matching support for `Float` objects
- Add serialize/bencode support for `Float` objects