### PR TITLE
Remove code scrollbars unless there is overflow

### DIFF
--- a/style.css
+++ b/style.css
@@ -134,7 +134,7 @@ a:hover {
 }
 
 pre {
-  overflow-x: scroll;
+  overflow-x: auto;
 }
 code,
 pre,


### PR DESCRIPTION
Looks goofy on Chrome right now because there are always scrollbars.
After this change there will be scrollbars only if it's too long a line.
