### PR TITLE
Make serialization work recursively

### DIFF
--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1393,6 +1393,11 @@ class Serializer:
             **{key.encode("utf-8"): value for key, value in kwargs.items()},
         }
 
+    # A little bit of Python shenanigans to intercept function entry and exit.
+    # We memoize the function by keeping track of what Objects have already
+    # been serialized so as to 1) de-duplicate and b) serialize cycles with
+    # Refs. If your implementation language does not have cycles, you can put
+    # code at the begin and end of `serialize` and it will work just the same.
     @_refwrap
     def serialize(self, obj: Object) -> Dict[bytes, object]:
         if isinstance(obj, Int):

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1403,6 +1403,8 @@ class Deserializer:
             self.link(idx)
         return self.objs[0]
 
+    # TODO(max): Figure out a way to link without having two entire functions
+    # that have knowledge about each object type
     def link(self, idx: int) -> None:
         obj = self.objs[idx]
         if isinstance(obj, (Int, String)):

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -518,6 +518,7 @@ class Object:
 
     @staticmethod
     def deserialize(msg: Dict[str, Any]) -> "Object":
+        # TODO(max): Handle refs
         assert "type" in msg, f"No idea what to do with {msg!r}"
         ty = msg["type"]
         assert isinstance(ty, str)

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1374,7 +1374,6 @@ def _refwrap(
         self.seen.append(obj)
         self.serialized.append({})
         result = f(self, obj)
-        assert isinstance(idx, int)
         assert not self.serialized[idx]
         self.serialized[idx] = result
         return {b"type": b"Ref", b"index": idx}

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1376,14 +1376,11 @@ class Serializer:
         self.objs.append(obj)
         return result, False
 
-    def _serialize(self, obj: Object, **kwargs: object) -> Dict[bytes, object]:
-        return {
+    def _serialize(self, ref: Dict[bytes, object], obj: Object, **kwargs: object) -> Dict[bytes, object]:
+        result = {
             b"type": type(obj).__name__.encode("utf-8"),
             **{key.encode("utf-8"): value for key, value in kwargs.items()},
         }
-
-    def _serialize_ref(self, ref: Dict[bytes, object], obj: Object, **kwargs: object) -> Dict[bytes, object]:
-        result = self._serialize(obj, **kwargs)
         idx = ref[b"index"]
         assert isinstance(idx, int)
         assert not self.refs[idx]
@@ -1396,9 +1393,9 @@ class Serializer:
             return ref
         self.refs.append({})
         if isinstance(obj, Int):
-            return self._serialize_ref(ref, obj, value=obj.value)
+            return self._serialize(ref, obj, value=obj.value)
         if isinstance(obj, List):
-            return self._serialize_ref(ref, obj, items=[self.serialize(item) for item in obj.items])
+            return self._serialize(ref, obj, items=[self.serialize(item) for item in obj.items])
         raise NotImplementedError("serialize", type(obj))
 
 

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1386,6 +1386,7 @@ class Serializer:
         result = self._serialize(obj, **kwargs)
         idx = ref[b"index"]
         assert isinstance(idx, int)
+        assert not self.refs[idx]
         self.refs[idx] = result
         return ref
 

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1373,9 +1373,8 @@ def _refwrap(
         idx = len(self.seen)
         self.seen.append(obj)
         self.serialized.append({})
-        result = f(self, obj)
         assert not self.serialized[idx]
-        self.serialized[idx] = result
+        self.serialized[idx] = f(self, obj)
         return {b"type": b"Ref", b"index": idx}
 
     return inner

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1370,7 +1370,7 @@ def _refwrap(
         idx = self.seen.get(id(obj))
         if idx is not None:
             return {b"type": b"Ref", b"index": idx}
-        self.seen[id(obj)] = idx = len(self.seen)
+        self.seen[id(obj)] = idx = len(self.serialized)
         self.serialized.append({})
         assert not self.serialized[idx]
         self.serialized[idx] = f(self, obj)
@@ -1382,6 +1382,9 @@ def _refwrap(
 class Serializer:
     def __init__(self) -> None:
         self.serialized: typing.List[Dict[bytes, object]] = []
+        # Map of Object address to index in `self.serialized`. Using addresses
+        # is safe because we assume all Objects involved in serialization are
+        # live at least until serialization is complete.
         self.seen: typing.Dict[int, int] = {}
 
     def _serialize(self, obj: Object, **kwargs: object) -> Dict[bytes, object]:


### PR DESCRIPTION
Use `Ref`s to get around recursion in JSON objects (which have no pointers).