### PR TITLE
Add a compiler from scrapscript to JS

### DIFF
--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1294,7 +1294,9 @@ class JSCompiler:
             if exp.value in ("true", "false"):
                 return exp.value
             return repr(exp.value)
-        raise NotImplementedError(exp)
+        if isinstance(exp, String):
+            return repr(exp.value)
+        raise NotImplementedError(type(exp), exp)
 
     def compile_match_case(self, env: Env, arg: str, case: MatchCase) -> Tuple[str, str]:
         pattern = case.pattern
@@ -4282,6 +4284,18 @@ class JSCompilerTests(unittest.TestCase):
     def test_compile_symbol(self) -> None:
         exp = Symbol("hello")
         self.assertEqual(compile_exp_js({}, exp), "'hello'")
+
+    def test_compile_string(self) -> None:
+        exp = String("hello")
+        self.assertEqual(compile_exp_js({}, exp), "'hello'")
+
+    def test_compile_string_single_quotes(self) -> None:
+        exp = String("'hello'")
+        self.assertEqual(compile_exp_js({}, exp), "\"'hello'\"")
+
+    def test_compile_string_double_quotes(self) -> None:
+        exp = String('"hello"')
+        self.assertEqual(compile_exp_js({}, exp), "'\"hello\"'")
 
 
 def fetch(url: Object) -> Object:

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1301,6 +1301,11 @@ class JSCompiler:
                 return f"{exp.obj}[{exp.at}]"
             assert isinstance(exp.at, Var)
             return f"{exp.obj}.{exp.at}"
+        if isinstance(exp, Record):
+            result = "{"
+            for key, rec_value in exp.data.items():
+                result += repr(key) + ":" + self.compile(env, rec_value) + ","
+            return result + "}"
         raise NotImplementedError(type(exp), exp)
 
     def compile_match_case(self, env: Env, arg: str, case: MatchCase) -> Tuple[str, str]:
@@ -4309,6 +4314,14 @@ class JSCompilerTests(unittest.TestCase):
     def test_compile_access_field(self) -> None:
         exp = Access(Var("x"), Var("y"))
         self.assertEqual(compile_exp_js({}, exp), "x.y")
+
+    def test_compile_empty_record(self) -> None:
+        exp = Record({})
+        self.assertEqual(compile_exp_js({}, exp), "{}")
+
+    def test_compile_record(self) -> None:
+        exp = Record({"a": Int(1), "b": Int(2)})
+        self.assertEqual(compile_exp_js({}, exp), "{'a':1,'b':2,}")
 
 
 def fetch(url: Object) -> Object:

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1295,6 +1295,10 @@ class JSCompiler:
                 cond, body = self.compile_match_case(env, arg, case)
                 result += f"if ({cond}) {{ {body} }}\n"
             return result + "}"
+        if isinstance(exp, Symbol):
+            if exp.value in ("true", "false"):
+                return exp.value
+            return repr(exp.value)
         raise NotImplementedError(exp)
 
     def compile_match_case(self, env: Env, arg: str, case: MatchCase) -> Tuple[str, str]:
@@ -4271,6 +4275,18 @@ class JSCompilerTests(unittest.TestCase):
             compile_exp_js({}, exp),
             "(__x) => {\nif (__x === 1) { return 2; }\nif (true) { const x = __x; return x; }\n}",
         )
+
+    def test_compile_symbol_bool_true(self) -> None:
+        exp = Symbol("true")
+        self.assertEqual(compile_exp_js({}, exp), "true")
+
+    def test_compile_symbol_bool_false(self) -> None:
+        exp = Symbol("false")
+        self.assertEqual(compile_exp_js({}, exp), "false")
+
+    def test_compile_symbol(self) -> None:
+        exp = Symbol("hello")
+        self.assertEqual(compile_exp_js({}, exp), "'hello'")
 
 
 def fetch(url: Object) -> Object:

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1296,6 +1296,11 @@ class JSCompiler:
             return repr(exp.value)
         if isinstance(exp, String):
             return repr(exp.value)
+        if isinstance(exp, Access):
+            if isinstance(exp.at, Int):
+                return f"{exp.obj}[{exp.at}]"
+            assert isinstance(exp.at, Var)
+            return f"{exp.obj}.{exp.at}"
         raise NotImplementedError(type(exp), exp)
 
     def compile_match_case(self, env: Env, arg: str, case: MatchCase) -> Tuple[str, str]:
@@ -4296,6 +4301,14 @@ class JSCompilerTests(unittest.TestCase):
     def test_compile_string_double_quotes(self) -> None:
         exp = String('"hello"')
         self.assertEqual(compile_exp_js({}, exp), "'\"hello\"'")
+
+    def test_compile_access_int(self) -> None:
+        exp = Access(Var("x"), Int(1))
+        self.assertEqual(compile_exp_js({}, exp), "x[1]")
+
+    def test_compile_access_field(self) -> None:
+        exp = Access(Var("x"), Var("y"))
+        self.assertEqual(compile_exp_js({}, exp), "x.y")
 
 
 def fetch(url: Object) -> Object:

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -4625,5 +4625,37 @@ def main() -> None:
         args.func(args)
 
 
+print(
+    compile_exp_js(
+        {},
+        parse(
+            tokenize(
+                """
+rand_array (new_generator 42) 0 100 10
+
+. rand_array = gen -> min -> max -> n -> n |>
+  | 0 -> []
+  | n -> (rand_val >+ rand_array new_gen min max (n - 1)
+    . rand_val = get_int new_gen
+    . new_gen = next gen min max)
+
+-- from Java's java.util.Random
+. new_generator = seed -> ({params = params, seed = seed, state = state}
+  . params = {mod = 281474976710656, mult = 25214903917, inc = 11}
+  . state = {min = 0, max = 0})
+
+. get_int = gen -> $$floor (get gen)
+
+. get = gen -> (gen@seed / gen@params@mod) * (gen@state@max - gen@state@min)
+
+. next = gen -> min -> max -> ({params = gen@params, seed = next_seed, state = {min = min, max = max}}
+  . next_seed = gen@state@min + (gen@seed * gen@params@mult + gen@params@inc) % gen@params@mod)
+"""
+            )
+        ),
+    )
+)
+
+
 if __name__ == "__main__":
     main()

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1297,10 +1297,11 @@ class JSCompiler:
         if isinstance(exp, String):
             return repr(exp.value)
         if isinstance(exp, Access):
+            obj = self.compile(env, exp.obj)
             if isinstance(exp.at, Int):
-                return f"{exp.obj}[{exp.at}]"
+                return f"{obj}[{exp.at}]"
             assert isinstance(exp.at, Var)
-            return f"{exp.obj}.{exp.at}"
+            return f"{obj}.{exp.at}"
         if isinstance(exp, Record):
             result = "{"
             for key, rec_value in exp.data.items():
@@ -4314,6 +4315,10 @@ class JSCompilerTests(unittest.TestCase):
     def test_compile_access_field(self) -> None:
         exp = Access(Var("x"), Var("y"))
         self.assertEqual(compile_exp_js({}, exp), "x.y")
+
+    def test_compile_nested_access(self) -> None:
+        exp = Access(Access(Var("x"), Var("y")), Var("z"))
+        self.assertEqual(compile_exp_js({}, exp), "x.y.z")
 
     def test_compile_empty_record(self) -> None:
         exp = Record({})

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1322,7 +1322,7 @@ class JSCompiler:
         if isinstance(pattern, Int):
             return f"{arg} === {pattern.value}", ret(self.compile(env, body))
         if isinstance(pattern, Var):
-            return "true", self.compile_let(env, pattern.name, Var(arg), body)
+            return "true", ret(self.compile_let(env, pattern.name, Var(arg), body))
         raise NotImplementedError(type(pattern))
 
 
@@ -4287,7 +4287,7 @@ class JSCompilerTests(unittest.TestCase):
         exp = parse(tokenize("| 1 -> 2 | x -> x"))
         self.assertEqual(
             compile_exp_js({}, exp),
-            "(__x) => {\nif (__x === 1) { return 2; }\nif (true) { ((x) => (x))(__x) }\n}",
+            "(__x) => {\nif (__x === 1) { return 2; }\nif (true) { return ((x) => (x))(__x); }\n}",
         )
 
     def test_compile_symbol_bool_true(self) -> None:


### PR DESCRIPTION
This is a hacky prototype but shows how easy it would be to compile scrapscript->JS *in scrapscript*. Once I get tests for this working I would like to re-write in scrapscript and land that instead.