### PR TITLE
changed cli to use stdin and str instead of filenames

### DIFF
--- a/build-com
+++ b/build-com
@@ -18,6 +18,6 @@ cp style.css repl.html Lib
 cp python scrapscript.com
 ./zip -r scrapscript.com Lib .args
 echo "Testing..."
-./scrapscript.com apply "1+2"
+./scrapscript.com eval "1+2"
 cd "$PREV"
 cp "$DIR"/scrapscript.com .


### PR DESCRIPTION
The CLI currently accepts commands like this:
```bash
scrap eval file.scrap
scrap apply "1+1"
scrap yard push /tmp/yard file.scrap
```

I changed it to work like this:
```bash
SCRAPYARD=/tmp/scrapyard
scrap eval "1+1"
scrap apply "x->x" "1+1"
scrap yard push "x->x"
```

and it also works with stdin:
```bash
SCRAPYARD=/tmp/scrapyard
echo "1+1" | scrap eval
echo "1+1" | scrap apply "x->x"
echo "x->x" | scrap yard push
```

the previous filename behavior can be emulated like this:
```bash
SCRAPYARD=/tmp/scrapyard
scrap eval `cat file.scrap`
scrap apply `cat f.scrap` `cat x.scrap`
scrap yard push `cat file.scrap`
```