### PR TITLE
Improve improve_closure

### DIFF
--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1152,6 +1152,10 @@ def free_in(exp: Object) -> Set[str]:
         if not exp.items:
             return set()
         return set.union(*(free_in(item) for item in exp.items))
+    if isinstance(exp, Record):
+        if not exp.data:
+            return set()
+        return set.union(*(free_in(value) for key, value in exp.data.items()))
     if isinstance(exp, Function):
         assert isinstance(exp.arg, Var)
         return free_in(exp.body) - {exp.arg.name}
@@ -3534,6 +3538,12 @@ class ClosureOptimizeTests(unittest.TestCase):
 
     def test_list(self) -> None:
         self.assertEqual(free_in(List([Var("x"), Var("y")])), {"x", "y"})
+
+    def test_empty_record(self) -> None:
+        self.assertEqual(free_in(Record({})), set())
+
+    def test_record(self) -> None:
+        self.assertEqual(free_in(Record({"x": Var("x"), "y": Var("y")})), {"x", "y"})
 
     def test_function(self) -> None:
         exp = parse(tokenize("x -> x + y"))

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1142,6 +1142,10 @@ def free_in(exp: Object) -> Set[str]:
         return set()
     if isinstance(exp, Var):
         return {exp.name}
+    if isinstance(exp, Spread):
+        if exp.name is not None:
+            return {exp.name}
+        return set()
     if isinstance(exp, Binop):
         return free_in(exp.left) | free_in(exp.right)
     if isinstance(exp, List):
@@ -3502,6 +3506,14 @@ class ClosureOptimizeTests(unittest.TestCase):
 
     def test_hole(self) -> None:
         self.assertEqual(free_in(Hole()), set())
+
+    def test_spread(self) -> None:
+        self.assertEqual(free_in(Spread()), set())
+
+    def test_spread_name(self) -> None:
+        # TODO(max): Should this be assumed to always be in a place where it
+        # defines a name, and therefore never have free variables?
+        self.assertEqual(free_in(Spread("x")), {"x"})
 
     def test_nativefunction(self) -> None:
         self.assertEqual(free_in(NativeFunction("id", lambda x: x)), set())


### PR DESCRIPTION
Improve closures more eagerly (when they are created, even if not assigned),
and support free_in matching on lists and records.

- Improve closures when they are created
- Add free_in(Spread)
- Add free_in(MatchCase(List))
- Add free_in(Record)
- Add free_in(MatchCase(Record))
