### PR TITLE
Add guard expressions to pattern matching

### DIFF
--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1281,8 +1281,10 @@ def eval_exp(env: Env, exp: Object) -> Object:
         elif isinstance(callee.func, MatchFunction):
             arg = eval_exp(env, exp.arg)
             for case in callee.func.cases:
-                m = match(arg, case.pattern, env, case.guard)
+                m = match(arg, case.pattern)
                 if m is None:
+                    continue
+                if case.guard is not None and eval_exp({**env, **m}, case.guard) != Symbol("true"):
                     continue
                 return eval_exp({**callee.env, **m}, case.body)
             raise MatchError("no matching cases")

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -367,6 +367,13 @@ def parse_assign(tokens: typing.List[Token], p: float = 0) -> "Assign":
     return assign
 
 
+def build_match_case(expr: "Object") -> "MatchCase":
+    if not isinstance(expr, Function):
+        raise ParseError(f"expected function in match expression {expr!r}")
+    arg, body = expr.arg, expr.body
+    return MatchCase(arg, body)
+
+
 def parse(tokens: typing.List[Token], p: float = 0) -> "Object":
     if not tokens:
         raise UnexpectedEOFError("unexpected end of input")
@@ -404,15 +411,11 @@ def parse(tokens: typing.List[Token], p: float = 0) -> "Object":
             l = Spread()
     elif token == Operator("|"):
         expr = parse(tokens, PS["|"].pr)  # TODO: make this work for larger arities
-        if not isinstance(expr, Function):
-            raise ParseError(f"expected function in match expression {expr!r}")
-        cases = [MatchCase(expr.arg, expr.body)]
+        cases = [build_match_case(expr)]
         while tokens and tokens[0] == Operator("|"):
             tokens.pop(0)
             expr = parse(tokens, PS["|"].pr)  # TODO: make this work for larger arities
-            if not isinstance(expr, Function):
-                raise ParseError(f"expected function in match expression {expr!r}")
-            cases.append(MatchCase(expr.arg, expr.body))
+            cases.append(build_match_case(expr))
         l = MatchFunction(cases)
     elif isinstance(token, LeftParen):
         if isinstance(tokens[0], RightParen):

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -2342,17 +2342,28 @@ class ParserTests(unittest.TestCase):
     def test_parse_symbol_returns_symbol(self) -> None:
         self.assertEqual(parse([SymbolToken("abc")]), Symbol("abc"))
 
-    # def test_parse_guard(self) -> None:
-    #     self.assertEqual(
-    #         parse(tokenize("| x guard y -> x")),
-    #         MatchFunction([MatchCase(Guard(Var("x"), Var("y")), Var("x"))]),
-    #     )
+    def test_parse_guard(self) -> None:
+        self.assertEqual(
+            parse(tokenize("| x guard y -> x")),
+            MatchFunction([MatchCase(Var("x"), Var("y"), Var("x"))]),
+        )
 
-    # def test_parse_guard_exp(self) -> None:
-    #     self.assertEqual(
-    #         parse(tokenize("| x guard x==1 -> x")),
-    #         MatchFunction([MatchCase(Guard(Var("x"), Binop(BinopKind.EQUAL, Var("x"), Int(1))), Var("x"))]),
-    #     )
+    def test_parse_guard_exp(self) -> None:
+        self.assertEqual(
+            parse(tokenize("| x guard x==1 -> x")),
+            MatchFunction([MatchCase(Var("x"), Binop(BinopKind.EQUAL, Var("x"), Int(1)), Var("x"))]),
+        )
+
+    def test_parse_multiple_guards(self) -> None:
+        self.assertEqual(
+            parse(tokenize("| x guard y -> x | a guard b -> 1")),
+            MatchFunction(
+                [
+                    MatchCase(Var("x"), Var("y"), Var("x")),
+                    MatchCase(Var("a"), Var("b"), Int(1)),
+                ]
+            ),
+        )
 
 
 class MatchTests(unittest.TestCase):

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -345,7 +345,7 @@ PS = {
 HIGHEST_PREC: float = max(max(p.pl, p.pr) for p in PS.values())
 
 
-OPER_CHARS = set("".join(PS.keys())) - set("guard")
+OPER_CHARS = set(c for c in "".join(PS.keys()) if not c.isalpha())
 assert " " not in OPER_CHARS
 
 

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.10
+#!/usr/bin/env python3.8
 import argparse
 import base64
 import code

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.8
+#!/usr/bin/env python3.10
 import argparse
 import base64
 import code

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -305,7 +305,6 @@ PS = {
     "::": lp(2000),
     "@": rp(1001),
     "": rp(1000),
-    "guard": rp(5.5),
     ">>": lp(14),
     "<<": lp(14),
     "^": rp(13),
@@ -329,6 +328,7 @@ PS = {
     "||": rp(7),
     "|>": rp(6),
     "<|": lp(6),
+    "guard": rp(5.5),
     "->": lp(5),
     "|": rp(4.5),
     ":": lp(4.5),
@@ -345,7 +345,9 @@ PS = {
 HIGHEST_PREC: float = max(max(p.pl, p.pr) for p in PS.values())
 
 
-OPER_CHARS = set("".join(PS.keys())) - set("guard")
+# TODO(max): Consider making "guard" an operator with only punctuation (but
+# leave syntax-level "guard" keyword)
+OPER_CHARS = set(c for c in "".join(PS.keys()) if not c.isalpha())
 assert " " not in OPER_CHARS
 
 
@@ -2363,6 +2365,12 @@ class ParserTests(unittest.TestCase):
                     MatchCase(Var("a"), Var("b"), Int(1)),
                 ]
             ),
+        )
+
+    def test_parse_guard_pipe(self) -> None:
+        self.assertEqual(
+            parse(tokenize("| x guard x |> f -> x")),
+            MatchFunction([MatchCase(Var("x"), Apply(Var("f"), Var("x")), Var("x"))]),
         )
 
 


### PR DESCRIPTION
Adds guards to pattern matching:

```
id 2
. id =
  | x guard x==1 -> "one"
  | x -> "idk"
```

Where guards run in a merged version of the match case env and the env created by the pattern matching.