### PR TITLE
Don't mark record names as free variables

### DIFF
--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1162,7 +1162,7 @@ def free_in(exp: Object) -> Set[str]:
     if isinstance(exp, Apply):
         return free_in(exp.func) | free_in(exp.arg)
     if isinstance(exp, Access):
-        return free_in(exp.obj) | free_in(exp.at)
+        return free_in(exp.obj)
     if isinstance(exp, Where):
         assert isinstance(exp.binding, Assign)
         return (free_in(exp.body) - {exp.binding.name.name}) | free_in(exp.binding)
@@ -3513,7 +3513,7 @@ class ClosureOptimizeTests(unittest.TestCase):
         self.assertEqual(free_in(Apply(Var("x"), Var("y"))), {"x", "y"})
 
     def test_access(self) -> None:
-        self.assertEqual(free_in(Access(Var("x"), Var("y"))), {"x", "y"})
+        self.assertEqual(free_in(Access(Var("x"), Var("y"))), {"x"})
 
     def test_where(self) -> None:
         exp = parse(tokenize("x . x = 1"))


### PR DESCRIPTION
In `a.b`, `b` is not free; it's functionally a string.
