### PR TITLE
Fix mul/div precedence to parse left to right

### DIFF
--- a/scrapscript.py
+++ b/scrapscript.py
@@ -303,8 +303,8 @@ PS = {
     ">>": lp(14),
     "<<": lp(14),
     "^": rp(13),
-    "*": lp(12),
-    "/": lp(12),
+    "*": rp(12),
+    "/": rp(12),
     "//": lp(12),
     "%": lp(12),
     "+": lp(11),
@@ -1856,6 +1856,12 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(
             parse([Operator("-"), Name("l"), Operator("*"), Name("r")]),
             Binop(BinopKind.MUL, Binop(BinopKind.SUB, Int(0), Var("l")), Var("r")),
+        )
+
+    def test_parse_negative_mul_and_div_bind_left_to_right(self) -> None:
+        self.assertEqual(
+            parse([IntLit(1), Operator("/"), IntLit(3), Operator("*"), IntLit(3)]),
+            Binop(BinopKind.MUL, Binop(BinopKind.DIV, Int(1), Int(3)), Int(3)),
         )
 
     def test_parse_negative_int_binds_tighter_than_index(self) -> None:
@@ -3928,6 +3934,16 @@ class PreludeTests(EndToEndTestsBase):
         """
             ),
             Variant("true", Hole()),
+        )
+
+    def test_mult_and_div_have_left_to_right_precedence(self) -> None:
+        self.assertEqual(
+            self._run(
+                """
+        1 / 3 * 3
+        """
+            ),
+            Float(1.0),
         )
 
 

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1858,12 +1858,6 @@ class ParserTests(unittest.TestCase):
             Binop(BinopKind.MUL, Binop(BinopKind.SUB, Int(0), Var("l")), Var("r")),
         )
 
-    def test_parse_negative_mul_and_div_bind_left_to_right(self) -> None:
-        self.assertEqual(
-            parse([IntLit(1), Operator("/"), IntLit(3), Operator("*"), IntLit(3)]),
-            Binop(BinopKind.MUL, Binop(BinopKind.DIV, Int(1), Int(3)), Int(3)),
-        )
-
     def test_parse_negative_int_binds_tighter_than_index(self) -> None:
         self.assertEqual(
             parse([Operator("-"), Name("l"), Operator("@"), Name("r")]),
@@ -1930,6 +1924,12 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(
             parse([IntLit(1), Operator("*"), IntLit(2), Operator("+"), IntLit(3)]),
             Binop(BinopKind.ADD, Binop(BinopKind.MUL, Int(1), Int(2)), Int(3)),
+        )
+
+    def test_mul_and_div_bind_left_to_right(self) -> None:
+        self.assertEqual(
+            parse([IntLit(1), Operator("/"), IntLit(3), Operator("*"), IntLit(3)]),
+            Binop(BinopKind.MUL, Binop(BinopKind.DIV, Int(1), Int(3)), Int(3)),
         )
 
     def test_exp_binds_tighter_than_mul_right(self) -> None:

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -3936,7 +3936,7 @@ class PreludeTests(EndToEndTestsBase):
             Variant("true", Hole()),
         )
 
-    def test_mult_and_div_have_left_to_right_precedence(self) -> None:
+    def test_mul_and_div_have_left_to_right_precedence(self) -> None:
         self.assertEqual(
             self._run(
                 """


### PR DESCRIPTION
Multiply and divide should apply left to right when not parenthesized