### PR TITLE
Support named match spread for records

### DIFF
--- a/compiler.py
+++ b/compiler.py
@@ -202,10 +202,13 @@ class Compiler:
             self._emit(f"if (!is_record({arg})) {{ goto {fallthrough}; }}")
             updates = {}
             for key, pattern_value in pattern.data.items():
+                assert not isinstance(pattern_value, Spread), "record spread not yet supported"
                 key_idx = self.record_key(key)
                 record_value = self._mktemp(f"record_get({arg}, {key_idx})")
                 self._emit(f"if ({record_value} == NULL) {{ goto {fallthrough}; }}")
                 updates.update(self.try_match(env, record_value, pattern_value, fallthrough))
+            # TODO(max): Check that there are no other fields in the record,
+            # perhaps by length check
             return updates
         raise NotImplementedError("try_match", pattern)
 

--- a/compiler_tests.py
+++ b/compiler_tests.py
@@ -49,8 +49,15 @@ class CompilerEndToEndTests(unittest.TestCase):
     def test_match_list(self) -> None:
         self.assertEqual(self._run("f [4, 5] . f = | [1, 2] -> 3 | [4, 5] -> 6"), "6\n")
 
+    def test_match_list_spread(self) -> None:
+        self.assertEqual(self._run("f [4, 5] . f = | [_, ...xs] -> xs"), "[5]\n")
+
     def test_match_record(self) -> None:
         self.assertEqual(self._run("f {a = 4, b = 5} . f = | {a = 1, b = 2} -> 3 | {a = 4, b = 5} -> 6"), "6\n")
+
+    @unittest.skip("TODO")
+    def test_match_record_spread(self) -> None:
+        self.assertEqual(self._run("f {a=1, b=2, c=3} . f = | {a=1, ...rest} -> rest"), "[5]\n")
 
     def test_match_hole(self) -> None:
         self.assertEqual(self._run("f () . f = | 1 -> 3 | () -> 4"), "4\n")


### PR DESCRIPTION
We supported `| [...xs]` but by accident not `| {...rest}`. It's a
little finicky but seems fine.