### PR TITLE
Allocate a separate const heap

### DIFF
--- a/compiler.py
+++ b/compiler.py
@@ -305,6 +305,10 @@ class Compiler:
             self.variant_tag(exp.tag)
             value = self._emit_const(exp.value)
             return self._const_obj("variant", "TAG_VARIANT", f".tag=Tag_{exp.tag}, .value={value}")
+        if isinstance(exp, Record):
+            values = {self.record_key(key): self._emit_const(value) for key, value in exp.data.items()}
+            fields = ",\n".join(f"{{.key={key}, .value={value} }}" for key, value in values.items())
+            return self._const_obj("record", "TAG_RECORD", f".size={len(values)}, .fields={{ {fields} }}")
         raise NotImplementedError(f"const {exp}")
 
     def compile(self, env: Env, exp: Object) -> str:

--- a/compiler.py
+++ b/compiler.py
@@ -288,8 +288,7 @@ class Compiler:
         result = self.gensym(f"const_{type}")
         section = '__attribute__((section("const_heap")))'
         self.const_heap.append(f"{section} struct {type} {result} = {{.HEAD.tag={tag}, {contents} }};")
-        self.const_heap.append(f"struct object* const {result}_ptr = (struct object*)((uword)&{result} + 1);")
-        return f"{result}_ptr"
+        return f"ptrto({result})"
 
     def _const_cons(self, first: str, rest: str) -> str:
         return self._const_obj("list", "TAG_LIST", f".first={first}, .rest={rest}")
@@ -502,6 +501,7 @@ def compile_to_string(source: str, debug: bool) -> str:
     for function in compiler.functions:
         print(function.decl() + ";", file=f)
     # Emit the const heap
+    print("#define ptrto(obj) ((struct object*)((uword)&(obj) + 1))", file=f)
     for line in compiler.const_heap:
         print(line, file=f)
     for function in compiler.functions:

--- a/compiler.py
+++ b/compiler.py
@@ -301,6 +301,10 @@ class Compiler:
             return self._const_obj(
                 "heap_string", "TAG_STRING", f".size={len(exp.value)}, .data={json.dumps(exp.value)}"
             )
+        if isinstance(exp, Variant):
+            self.variant_tag(exp.tag)
+            value = self._emit_const(exp.value)
+            return self._const_obj("variant", "TAG_VARIANT", f".tag=Tag_{exp.tag}, .value={value}")
         raise NotImplementedError(f"const {exp}")
 
     def compile(self, env: Env, exp: Object) -> str:

--- a/compiler.py
+++ b/compiler.py
@@ -285,7 +285,7 @@ class Compiler:
         return False
 
     def _const_obj(self, type: str, tag: str, contents: str) -> str:
-        result = self.gensym("const")
+        result = self.gensym(f"const_{type}")
         section = '__attribute__((section("const_heap")))'
         self.const_heap.append(f"{section} struct {type} {result} = {{.HEAD.tag={tag}, {contents} }};")
         self.const_heap.append(f"struct object* const {result}_ptr = (struct object*)((uword)&{result} + 1);")

--- a/compiler.py
+++ b/compiler.py
@@ -286,8 +286,7 @@ class Compiler:
 
     def _const_obj(self, type: str, tag: str, contents: str) -> str:
         result = self.gensym(f"const_{type}")
-        section = '__attribute__((section("const_heap")))'
-        self.const_heap.append(f"{section} struct {type} {result} = {{.HEAD.tag={tag}, {contents} }};")
+        self.const_heap.append(f"CONST_HEAP struct {type} {result} = {{.HEAD.tag={tag}, {contents} }};")
         return f"ptrto({result})"
 
     def _const_cons(self, first: str, rest: str) -> str:
@@ -502,6 +501,7 @@ def compile_to_string(source: str, debug: bool) -> str:
         print(function.decl() + ";", file=f)
     # Emit the const heap
     print("#define ptrto(obj) ((struct object*)((uword)&(obj) + 1))", file=f)
+    print('#define CONST_HEAP __attribute__((section("const_heap")))', file=f)
     for line in compiler.const_heap:
         print(line, file=f)
     for function in compiler.functions:

--- a/compiler.py
+++ b/compiler.py
@@ -287,6 +287,7 @@ class Compiler:
     def _emit_const(self, exp: Object) -> str:
         assert self._is_const(exp), f"not a constant {exp}"
         if isinstance(exp, Int):
+            # TODO(max): Bignum
             return f"(struct object*)(((uword){exp.value} << kSmallIntTagBits))"
         if isinstance(exp, List):
             items = [self._emit_const(item) for item in exp.items]

--- a/compiler.py
+++ b/compiler.py
@@ -272,6 +272,8 @@ class Compiler:
             return all(self._is_const(value) for value in exp.data.values())
         if isinstance(exp, List):
             return all(self._is_const(item) for item in exp.items)
+        if isinstance(exp, Hole):
+            return True
         return False
 
     def _const_obj(self, type: str, tag: str, contents: str) -> str:
@@ -286,6 +288,8 @@ class Compiler:
 
     def _emit_const(self, exp: Object) -> str:
         assert self._is_const(exp), f"not a constant {exp}"
+        if isinstance(exp, Hole):
+            return "((struct object*)kHoleTag)"
         if isinstance(exp, Int):
             # TODO(max): Bignum
             return f"(struct object*)(((uword){exp.value} << kSmallIntTagBits))"

--- a/compiler_tests.py
+++ b/compiler_tests.py
@@ -69,6 +69,9 @@ class CompilerEndToEndTests(unittest.TestCase):
     def test_variant(self) -> None:
         self.assertEqual(self._run("# foo 123"), "#foo 123\n")
 
+    def test_variant_builder(self) -> None:
+        self.assertEqual(self._run("f 123 . f = x -> # foo x"), "#foo 123\n")
+
     def test_function(self) -> None:
         self.assertEqual(self._run("f 1 . f = x -> x + 1"), "2\n")
 

--- a/compiler_tests.py
+++ b/compiler_tests.py
@@ -54,8 +54,14 @@ class CompilerEndToEndTests(unittest.TestCase):
     def test_record(self) -> None:
         self.assertEqual(self._run("{a = 1, b = 2}"), "{a = 1, b = 2}\n")
 
+    def test_record_builder(self) -> None:
+        self.assertEqual(self._run("f 1 2 . f = x -> y -> {a = x, b = y}"), "{a = 1, b = 2}\n")
+
     def test_record_access(self) -> None:
         self.assertEqual(self._run("rec@a . rec = {a = 1, b = 2}"), "1\n")
+
+    def test_record_builder_access(self) -> None:
+        self.assertEqual(self._run("(f 1 2)@a . f = x -> y -> {a = x, b = y}"), "1\n")
 
     def test_hole(self) -> None:
         self.assertEqual(self._run("()"), "()\n")

--- a/compiler_tests.py
+++ b/compiler_tests.py
@@ -75,6 +75,12 @@ class CompilerEndToEndTests(unittest.TestCase):
     def test_function(self) -> None:
         self.assertEqual(self._run("f 1 . f = x -> x + 1"), "2\n")
 
+    def test_anonymous_function_as_value(self) -> None:
+        self.assertEqual(self._run("x -> x"), "<closure>\n")
+
+    def test_anonymous_function(self) -> None:
+        self.assertEqual(self._run("((x -> x + 1) 1)"), "2\n")
+
     def test_match_int(self) -> None:
         self.assertEqual(self._run("f 3 . f = | 1 -> 2 | 3 -> 4"), "4\n")
 

--- a/compiler_tests.py
+++ b/compiler_tests.py
@@ -54,14 +54,12 @@ class CompilerEndToEndTests(unittest.TestCase):
     def test_record(self) -> None:
         self.assertEqual(self._run("{a = 1, b = 2}"), "{a = 1, b = 2}\n")
 
-    @unittest.skipIf("tcc" in os.environ.get("CC", ""), "TODO(max): Fix; TCC emits crashy code")
     def test_record_builder(self) -> None:
         self.assertEqual(self._run("f 1 2 . f = x -> y -> {a = x, b = y}"), "{a = 1, b = 2}\n")
 
     def test_record_access(self) -> None:
         self.assertEqual(self._run("rec@a . rec = {a = 1, b = 2}"), "1\n")
 
-    @unittest.skipIf("tcc" in os.environ.get("CC", ""), "TODO(max): Fix; TCC emits crashy code")
     def test_record_builder_access(self) -> None:
         self.assertEqual(self._run("(f 1 2)@a . f = x -> y -> {a = x, b = y}"), "1\n")
 
@@ -86,7 +84,6 @@ class CompilerEndToEndTests(unittest.TestCase):
     def test_match_int(self) -> None:
         self.assertEqual(self._run("f 3 . f = | 1 -> 2 | 3 -> 4"), "4\n")
 
-    @unittest.skipIf("tcc" in os.environ.get("CC", ""), "TODO(max): Fix; TCC emits crashy code")
     def test_match_list(self) -> None:
         self.assertEqual(self._run("f [4, 5] . f = | [1, 2] -> 3 | [4, 5] -> 6"), "6\n")
 

--- a/compiler_tests.py
+++ b/compiler_tests.py
@@ -54,12 +54,14 @@ class CompilerEndToEndTests(unittest.TestCase):
     def test_record(self) -> None:
         self.assertEqual(self._run("{a = 1, b = 2}"), "{a = 1, b = 2}\n")
 
+    @unittest.skipIf("tcc" in os.environ.get("CC", ""), "TODO(max): Fix; TCC emits crashy code")
     def test_record_builder(self) -> None:
         self.assertEqual(self._run("f 1 2 . f = x -> y -> {a = x, b = y}"), "{a = 1, b = 2}\n")
 
     def test_record_access(self) -> None:
         self.assertEqual(self._run("rec@a . rec = {a = 1, b = 2}"), "1\n")
 
+    @unittest.skipIf("tcc" in os.environ.get("CC", ""), "TODO(max): Fix; TCC emits crashy code")
     def test_record_builder_access(self) -> None:
         self.assertEqual(self._run("(f 1 2)@a . f = x -> y -> {a = x, b = y}"), "1\n")
 

--- a/runtime.c
+++ b/runtime.c
@@ -182,21 +182,19 @@ struct object* heap_tag(uintptr_t addr) {
 char* __start_const_heap;
 char* __stop_const_heap;
 
-bool in_const_heap(struct object* obj) {
-  assert(is_heap_object(obj));
-  struct gc_obj* heap_obj = as_heap_object(obj);
-  return (uword)heap_obj >= (uword)&__start_const_heap &&
-         (uword)heap_obj < (uword)&__stop_const_heap;
+bool in_const_heap(struct gc_obj* obj) {
+  return (uword)obj >= (uword)&__start_const_heap &&
+         (uword)obj < (uword)&__stop_const_heap;
 }
 
 void visit_field(struct object** pointer, struct gc_heap* heap) {
   if (!is_heap_object(*pointer)) {
     return;
   }
-  if (in_const_heap(*pointer)) {
+  struct gc_obj* from = as_heap_object(*pointer);
+  if (in_const_heap(from)) {
     return;
   }
-  struct gc_obj* from = as_heap_object(*pointer);
   struct gc_obj* to = is_forwarded(from) ? forwarded(from) : copy(heap, from);
   *pointer = heap_tag((uintptr_t)to);
 }

--- a/runtime.c
+++ b/runtime.c
@@ -743,3 +743,9 @@ struct object* println(struct object* obj) {
   putchar('\n');
   return obj;
 }
+
+// Put something in the const heap so that __start_const_heap and
+// __stop_const_heap are defined by the linker.
+__attribute__((section("const_heap"), used)) struct heap_string private_unused_const_heap = {
+    .HEAD.tag = TAG_STRING, .size = 11, .data = "hello world"
+};

--- a/runtime.c
+++ b/runtime.c
@@ -179,8 +179,21 @@ struct object* heap_tag(uintptr_t addr) {
   return (struct object*)(addr | (uword)1ULL);
 }
 
+extern char* __start_const_heap;
+extern char* __stop_const_heap;
+
+bool in_const_heap(struct object* obj) {
+  assert(is_heap_object(obj));
+  struct gc_obj* heap_obj = as_heap_object(obj);
+  return (uword)heap_obj >= (uword)&__start_const_heap &&
+         (uword)heap_obj < (uword)&__stop_const_heap;
+}
+
 void visit_field(struct object** pointer, struct gc_heap* heap) {
   if (!is_heap_object(*pointer)) {
+    return;
+  }
+  if (in_const_heap(*pointer)) {
     return;
   }
   struct gc_obj* from = as_heap_object(*pointer);

--- a/runtime.c
+++ b/runtime.c
@@ -179,8 +179,8 @@ struct object* heap_tag(uintptr_t addr) {
   return (struct object*)(addr | (uword)1ULL);
 }
 
-extern char* __start_const_heap;
-extern char* __stop_const_heap;
+char* __start_const_heap;
+char* __stop_const_heap;
 
 bool in_const_heap(struct object* obj) {
   assert(is_heap_object(obj));

--- a/runtime.c
+++ b/runtime.c
@@ -179,12 +179,21 @@ struct object* heap_tag(uintptr_t addr) {
   return (struct object*)(addr | (uword)1ULL);
 }
 
-char* __start_const_heap;
-char* __stop_const_heap;
+#ifdef __TINYC__
+// libc defines __attribute__ as an empty macro if the compiler is not GCC or
+// GCC < 2. We know tcc has supported __attribute__(section(...)) for 20+ years
+// so we can undefine it.
+// See tinycc-devel: https://lists.nongnu.org/archive/html/tinycc-devel/2018-04/msg00008.html
+// and my StackOverflow question: https://stackoverflow.com/q/78638571/569183
+#undef __attribute__
+#endif
+
+extern char __start_const_heap[];
+extern char __stop_const_heap[];
 
 bool in_const_heap(struct gc_obj* obj) {
-  return (uword)obj >= (uword)&__start_const_heap &&
-         (uword)obj < (uword)&__stop_const_heap;
+  return (uword)obj >= (uword)__start_const_heap &&
+         (uword)obj < (uword)__stop_const_heap;
 }
 
 void visit_field(struct object** pointer, struct gc_heap* heap) {


### PR DESCRIPTION
Allocate the memory in a separate section, `const_heap`, and don't visit it during GC.

Output constant objects at the top level for `[1,2,3]` look like:

```c
CONST_HEAP struct list const_list_0 = {
    .HEAD.tag = TAG_LIST,
    .first = (struct object*)(((uword)3 << kSmallIntTagBits)),
    .rest = ((struct object*)kEmptyListTag)};
CONST_HEAP struct list const_list_1 = {
    .HEAD.tag = TAG_LIST,
    .first = (struct object*)(((uword)2 << kSmallIntTagBits)),
    .rest = ptrto(const_list_0)};
CONST_HEAP struct list const_list_2 = {
    .HEAD.tag = TAG_LIST,
    .first = (struct object*)(((uword)1 << kSmallIntTagBits)),
    .rest = ptrto(const_list_1)};
```

Fix #157.