### PR TITLE
Encode everything smaller (flat scraps)

### DIFF
--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1011,17 +1011,21 @@ class Variant(Object):
         return f"#{self.tag} {self.value}"
 
 
-TYPE_I8 = b"1"
-TYPE_I16 = b"2"
-TYPE_I32 = b"4"
-TYPE_I64 = b"8"
-TYPE_LONG = b"l"
-TYPE_STRING = b"s"
-TYPE_REF = b"r"
-TYPE_LIST = b"["
-TYPE_RECORD = b"{"
-TYPE_VARIANT = b"#"
+tags = [
+    TYPE_I8 := b"1",
+    TYPE_I16 := b"2",
+    TYPE_I32 := b"4",
+    TYPE_I64 := b"8",
+    TYPE_LONG := b"l",
+    TYPE_STRING := b"s",
+    TYPE_REF := b"r",
+    TYPE_LIST := b"[",
+    TYPE_RECORD := b"{",
+    TYPE_VARIANT := b"#",
+]
 FLAG_REF = 0x80
+tags = tags + [(v[0] | FLAG_REF).to_bytes(1, "little") for v in tags]
+assert len(tags) == len(set(tags)), "Duplicate tags"
 
 
 @dataclass
@@ -1080,6 +1084,7 @@ class Serializer:
             return
         if isinstance(obj, Variant):
             self.emit(TYPE_VARIANT)
+            # TODO(max): String pool (via refs) for strings longer than some length?
             self.emit(TYPE_STRING + self._string(obj.tag))
             return self.serialize(obj.value)
         raise NotImplementedError(type(obj))

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1098,7 +1098,7 @@ class Serializer:
             self.add_ref(TYPE_RECORD, obj)
             self.emit(self._count(len(obj.data)))
             for key, value in obj.data.items():
-                self.emit(TYPE_STRING + self._string(key))
+                self.emit(self._string(key))
                 self.serialize(value)
             return
         raise NotImplementedError(type(obj))
@@ -4366,7 +4366,7 @@ class SerializerTests(unittest.TestCase):
     def test_record(self) -> None:
         obj = Record({"x": Int(1), "y": Int(2)})
         self.assertEqual(
-            self._serialize(obj), ref(TYPE_RECORD) + b"\x02\x00\x00\x00s\x01\x00\x00\x00x1\x01s\x01\x00\x00\x00y1\x02"
+            self._serialize(obj), ref(TYPE_RECORD) + b"\x02\x00\x00\x00\x01\x00\x00\x00x1\x01\x01\x00\x00\x00y1\x02"
         )
 
 

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -914,8 +914,7 @@ class Serializer:
         while number:
             digits.append(number & DIGIT_MASK)
             number >>= BITS_PER_DIGIT
-        buf = bytearray()
-        self.emit(self._short(len(digits)))
+        buf = bytearray(self._short(len(digits)))
         for digit in digits:
             buf.extend(digit.to_bytes(BYTES_PER_DIGIT, "little"))
         return bytes(buf)

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1090,12 +1090,14 @@ class Serializer:
                 self.serialize(item)
             return
         if isinstance(obj, Variant):
+            # TODO(max): Determine if this should be a ref
             self.emit(TYPE_VARIANT)
             # TODO(max): String pool (via refs) for strings longer than some length?
             self.emit(TYPE_STRING + self._string(obj.tag))
             return self.serialize(obj.value)
         if isinstance(obj, Record):
-            self.add_ref(TYPE_RECORD, obj)
+            # TODO(max): Determine if this should be a ref
+            self.emit(TYPE_RECORD)
             self.emit(self._count(len(obj.data)))
             for key, value in obj.data.items():
                 self.emit(self._string(key))
@@ -4366,7 +4368,7 @@ class SerializerTests(unittest.TestCase):
     def test_record(self) -> None:
         obj = Record({"x": Int(1), "y": Int(2)})
         self.assertEqual(
-            self._serialize(obj), ref(TYPE_RECORD) + b"\x02\x00\x00\x00\x01\x00\x00\x00x1\x01\x01\x00\x00\x00y1\x02"
+            self._serialize(obj), TYPE_RECORD + b"\x02\x00\x00\x00\x01\x00\x00\x00x1\x01\x01\x00\x00\x00y1\x02"
         )
 
 

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1043,6 +1043,7 @@ def ref(tag):
 
 tags = tags + [ref(v) for v in tags]
 assert len(tags) == len(set(tags)), "Duplicate tags"
+assert all(len(v) == 1 for v in tags), "Tags must be 1 byte"
 
 
 COUNT_NBYTES = 4

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1012,7 +1012,7 @@ class Serializer:
 
 @dataclass
 class Deserializer:
-    flat: bytes | memoryview
+    flat: Union[bytes, memoryview]
     idx: int = 0
     refs: typing.List[Object] = dataclasses.field(default_factory=list)
 

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -15,7 +15,7 @@ import unittest
 import urllib.request
 from dataclasses import dataclass
 from enum import auto
-from types import FunctionType, ModuleType
+from types import ModuleType
 from typing import Any, Callable, Dict, Mapping, Optional, Set, Tuple, Union
 
 readline: Optional[ModuleType]

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1080,7 +1080,6 @@ class Serializer:
     def serialize(self, obj: Object) -> None:
         assert isinstance(obj, Object), type(obj)
         if (ref := self.ref(obj)) is not None:
-            self.emit(TYPE_REF)
             return self.emit(TYPE_REF + self._count(ref))
         if isinstance(obj, Int):
             return self._long(obj.value)
@@ -4394,7 +4393,7 @@ class SerializerTests(unittest.TestCase):
     def test_self_referential_list(self) -> None:
         obj = List([])
         obj.items.append(obj)
-        self.assertEqual(self._serialize(obj), ref(TYPE_LIST) + b"\x01\x00\x00\x00rr\x00\x00\x00\x00")
+        self.assertEqual(self._serialize(obj), ref(TYPE_LIST) + b"\x01\x00\x00\x00r\x00\x00\x00\x00")
 
     def test_variant(self) -> None:
         obj = Variant("abc", Int(123))

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -4055,7 +4055,7 @@ class SerializerTests(unittest.TestCase):
         serializer.serialize(obj)
         return bytes(serializer.output)
 
-    def test_smallints(self) -> None:
+    def test_short(self) -> None:
         self.assertEqual(self._serialize(Int(-1)), TYPE_SHORT + b"\x01")
         self.assertEqual(self._serialize(Int(0)), TYPE_SHORT + b"\x00")
         self.assertEqual(self._serialize(Int(1)), TYPE_SHORT + b"\x02")
@@ -4064,7 +4064,7 @@ class SerializerTests(unittest.TestCase):
         self.assertEqual(self._serialize(Int(-(2**63))), TYPE_SHORT + b"\xff\xff\xff\xff\xff\xff\xff\xff\xff\x01")
         self.assertEqual(self._serialize(Int(2**63 - 1)), TYPE_SHORT + b"\xfe\xff\xff\xff\xff\xff\xff\xff\xff\x01")
 
-    def test_bigints(self) -> None:
+    def test_long(self) -> None:
         self.assertEqual(
             self._serialize(Int(2**100)),
             TYPE_LONG + b"\x04\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00 \x00\x00\x00",
@@ -4178,15 +4178,14 @@ class RoundTripSerializationTests(unittest.TestCase):
         result = self._serde(obj)
         self.assertEqual(result, obj)
 
-    def test_smallints(self) -> None:
+    def test_short(self) -> None:
         for i in range(-(2**16), 2**16):
             self._rt(Int(i))
 
-    def test_i64(self) -> None:
         self._rt(Int(-(2**63)))
         self._rt(Int(2**63 - 1))
 
-    def test_bigints(self) -> None:
+    def test_long(self) -> None:
         self._rt(Int(2**100))
         self._rt(Int(-(2**100)))
 

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1065,7 +1065,8 @@ class Serializer:
         return obj.to_bytes(4, "little")
 
     def _string(self, obj: str) -> bytes:
-        return obj.encode("utf-8")
+        encoded = obj.encode("utf-8")
+        return self._count(len(encoded)) + encoded
 
     def serialize(self, obj: Object) -> None:
         assert isinstance(obj, Object), type(obj)
@@ -4330,7 +4331,7 @@ class SerializerTests(unittest.TestCase):
         self.assertEqual(self._serialize(Int(2**32 + 1)), TYPE_I64 + b"\x01\x00\x00\x00\x01\x00\x00\x00")
 
     def test_string(self) -> None:
-        self.assertEqual(self._serialize(String("hello")), b"shello")
+        self.assertEqual(self._serialize(String("hello")), b's\x05\x00\x00\x00hello')
 
     def test_empty_list(self) -> None:
         obj = List([])
@@ -4347,7 +4348,7 @@ class SerializerTests(unittest.TestCase):
 
     def test_variant(self) -> None:
         obj = Variant("abc", Int(123))
-        self.assertEqual(self._serialize(obj), b"#sabc1{")
+        self.assertEqual(self._serialize(obj), b'#s\x03\x00\x00\x00abc1{')
 
 
 class ScrapMonadTests(unittest.TestCase):

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1046,6 +1046,7 @@ def ref(tag):
 tags = tags + [ref(v) for v in tags]
 assert len(tags) == len(set(tags)), "Duplicate tags"
 assert all(len(v) == 1 for v in tags), "Tags must be 1 byte"
+assert all(isinstance(v, bytes) for v in tags)
 
 
 COUNT_NBYTES = 4

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -5085,6 +5085,13 @@ def compile_command(args: argparse.Namespace) -> None:
         subprocess.run(["sh", "-c", "./a.out"], check=True)
 
 
+def flat_command(args: argparse.Namespace) -> None:
+    prog = parse(tokenize(sys.stdin.read()))
+    serializer = Serializer()
+    serializer.serialize(prog)
+    sys.stdout.buffer.write(serializer.output)
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(prog="scrapscript")
     subparsers = parser.add_subparsers(dest="command")
@@ -5119,6 +5126,9 @@ def main() -> None:
     comp.add_argument("--debug", action="store_true", default=False)
     # The platform is in the same directory as this file
     comp.add_argument("--platform", default=os.path.join(os.path.dirname(__file__), "cli.c"))
+
+    flat = subparsers.add_parser("flat")
+    flat.set_defaults(func=flat_command)
 
     args = parser.parse_args()
     if not args.command:


### PR DESCRIPTION
This also supports recursive serialization for e.g. closures.

Fixes #47, #44.