### PR TITLE
Encode variants with holes as immediates

### DIFF
--- a/compiler.py
+++ b/compiler.py
@@ -471,6 +471,11 @@ def compile_to_string(source: str, debug: bool) -> str:
         ("uword", "kEmptyListTag", 5),  # 0b00101
         ("uword", "kHoleTag", 7),  # 0b00111
         ("uword", "kSmallStringTag", 13),  # 0b01101
+        # TODO(max): Fill in 15
+        # TODO(max): Fill in 21
+        # TODO(max): Fill in 23
+        # TODO(max): Fill in 29
+        # TODO(max): Fill in 31
         ("uword", "kBitsPerPointer", "kBitsPerByte * kWordSize"),
         ("word", "kSmallIntBits", "kBitsPerPointer - kSmallIntTagBits"),
         ("word", "kSmallIntMinValue", "-(((word)1) << (kSmallIntBits - 1))"),

--- a/compiler.py
+++ b/compiler.py
@@ -321,7 +321,7 @@ class Compiler:
             return f"_mksmallint({exp.value})"
         if isinstance(exp, List):
             items = [self._emit_const(item) for item in exp.items]
-            result = "((struct object*)kEmptyListTag)"
+            result = "empty_list()"
             for item in reversed(items):
                 result = self._const_cons(item, result)
             return result

--- a/compiler.py
+++ b/compiler.py
@@ -318,7 +318,7 @@ class Compiler:
             return "((struct object*)kHoleTag)"
         if isinstance(exp, Int):
             # TODO(max): Bignum
-            return f"(struct object*)(((uword){exp.value} << kSmallIntTagBits))"
+            return f"_mksmallint({exp.value})"
         if isinstance(exp, List):
             items = [self._emit_const(item) for item in exp.items]
             result = "((struct object*)kEmptyListTag)"

--- a/compiler.py
+++ b/compiler.py
@@ -305,12 +305,8 @@ class Compiler:
         value = value_str.encode("utf-8")
         length = len(value)
         assert length < 8, "small string must be less than 8 bytes"
-        kImmediateTagBits = 5
-        kSmallStringTag = 13
-        tag = (length << kImmediateTagBits) | kSmallStringTag
-        encoded = value[::-1] + bytes([tag])
-        value_int = int.from_bytes(encoded, "big")
-        return f"(struct object*)({hex(value_int)}ULL /* {value_str!r} */)"
+        value_int = int.from_bytes(value[::-1], "big")
+        return f"(struct object*)(({hex(value_int)}ULL << kBitsPerByte) | ({length}ULL << kImmediateTagBits) | (uword)kSmallStringTag /* {value_str!r} */)"
 
     def _emit_const(self, exp: Object) -> str:
         assert self._is_const(exp), f"not a constant {exp}"

--- a/compiler.py
+++ b/compiler.py
@@ -315,7 +315,7 @@ class Compiler:
     def _emit_const(self, exp: Object) -> str:
         assert self._is_const(exp), f"not a constant {exp}"
         if isinstance(exp, Hole):
-            return "((struct object*)kHoleTag)"
+            return "hole()"
         if isinstance(exp, Int):
             # TODO(max): Bignum
             return f"_mksmallint({exp.value})"

--- a/compiler.py
+++ b/compiler.py
@@ -187,6 +187,11 @@ class Compiler:
             return {}
         if isinstance(pattern, Variant):
             self.variant_tag(pattern.tag)  # register it for the big enum
+            if isinstance(pattern.value, Hole):
+                # This is an optimization for immediate variants but it's not
+                # necessary; the non-Hole case would work just fine.
+                self._emit(f"if ({arg} != mk_immediate_variant(Tag_{pattern.tag})) {{ goto {fallthrough}; }}")
+                return {}
             self._emit(f"if (!is_variant({arg})) {{ goto {fallthrough}; }}")
             self._emit(f"if (variant_tag({arg}) != Tag_{pattern.tag}) {{ goto {fallthrough}; }}")
             return self.try_match(env, self._mktemp(f"variant_value({arg})"), pattern.value, fallthrough)

--- a/compiler.py
+++ b/compiler.py
@@ -328,6 +328,8 @@ class Compiler:
             )
         if isinstance(exp, Variant):
             self.variant_tag(exp.tag)
+            if isinstance(exp.value, Hole):
+                return f"mk_immediate_variant(Tag_{exp.tag})"
             value = self._emit_const(exp.value)
             return self._const_obj("variant", "TAG_VARIANT", f".tag=Tag_{exp.tag}, .value={value}")
         if isinstance(exp, Record):
@@ -471,7 +473,7 @@ def compile_to_string(source: str, debug: bool) -> str:
         ("uword", "kEmptyListTag", 5),  # 0b00101
         ("uword", "kHoleTag", 7),  # 0b00111
         ("uword", "kSmallStringTag", 13),  # 0b01101
-        # TODO(max): Fill in 15
+        ("uword", "kVariantTag", 15),  # 0b01111
         # TODO(max): Fill in 21
         # TODO(max): Fill in 23
         # TODO(max): Fill in 29

--- a/compiler_tests.py
+++ b/compiler_tests.py
@@ -112,8 +112,11 @@ class CompilerEndToEndTests(unittest.TestCase):
     def test_match_hole(self) -> None:
         self.assertEqual(self._run("f () . f = | 1 -> 3 | () -> 4"), "4\n")
 
-    def test_match_variant(self) -> None:
+    def test_match_immediate_variant(self) -> None:
         self.assertEqual(self._run("f #foo () . f = | # bar 1 -> 3 | # foo () -> 4"), "4\n")
+
+    def test_match_heap_variant(self) -> None:
+        self.assertEqual(self._run("f #bar 1 . f = | # bar 1 -> 3 | # foo () -> 4"), "3\n")
 
 
 if __name__ == "__main__":

--- a/runtime.c
+++ b/runtime.c
@@ -381,9 +381,12 @@ bool smallint_is_valid(word value) {
   return (value >= kSmallIntMinValue) && (value <= kSmallIntMaxValue);
 }
 
+#define _mksmallint(value)                                                     \
+  (struct object*)(((uword)(value) << kSmallIntTagBits) | kSmallIntTag)
+
 struct object* mksmallint(word value) {
   assert(smallint_is_valid(value));
-  return (struct object*)(((uword)value << kSmallIntTagBits));
+  return _mksmallint(value);
 }
 
 struct object* mknum(struct gc_heap* heap, word value) {

--- a/runtime.c
+++ b/runtime.c
@@ -70,7 +70,8 @@ static ALWAYS_INLINE struct object* mksmallstring(const char* data,
   assert(small_string_length(result_obj) == length);
   return result_obj;
 }
-bool is_empty_string(struct object* obj) { return obj == mksmallstring("", 0); }
+struct object* empty_string() { return (struct object*)kSmallStringTag; }
+bool is_empty_string(struct object* obj) { return obj == empty_string(); }
 static ALWAYS_INLINE char small_string_at(struct object* obj, uword index) {
   assert(is_small_string(obj));
   assert(index < small_string_length(obj));

--- a/runtime.c
+++ b/runtime.c
@@ -38,7 +38,7 @@ bool is_heap_object(struct object* obj) {
 }
 struct object* empty_list() { return (struct object*)kEmptyListTag; }
 bool is_empty_list(struct object* obj) { return obj == empty_list(); }
-struct object* hole() { return (struct object*)kHoleTag; }
+#define hole() ((struct object*)kHoleTag)
 bool is_hole(struct object* obj) { return (uword)obj == kHoleTag; }
 static ALWAYS_INLINE bool is_small_string(struct object* obj) {
   return (((uword)obj) & kImmediateTagMask) == kSmallStringTag;

--- a/runtime.c
+++ b/runtime.c
@@ -36,7 +36,7 @@ bool is_immediate_not_small_int(struct object* obj) {
 bool is_heap_object(struct object* obj) {
   return (((uword)obj) & kPrimaryTagMask) == kHeapObjectTag;
 }
-struct object* empty_list() { return (struct object*)kEmptyListTag; }
+#define empty_list() ((struct object*)kEmptyListTag)
 bool is_empty_list(struct object* obj) { return obj == empty_list(); }
 #define hole() ((struct object*)kHoleTag)
 bool is_hole(struct object* obj) { return (uword)obj == kHoleTag; }

--- a/runtime.c
+++ b/runtime.c
@@ -39,9 +39,7 @@ bool is_heap_object(struct object* obj) {
 struct object* empty_list() { return (struct object*)kEmptyListTag; }
 bool is_empty_list(struct object* obj) { return obj == empty_list(); }
 struct object* hole() { return (struct object*)kHoleTag; }
-bool is_hole(struct object* obj) {
-  return (((uword)obj) & kImmediateTagMask) == kHoleTag;
-}
+bool is_hole(struct object* obj) { return (uword)obj == kHoleTag; }
 static ALWAYS_INLINE bool is_small_string(struct object* obj) {
   return (((uword)obj) & kImmediateTagMask) == kSmallStringTag;
 }


### PR DESCRIPTION
This is inspired by the OCaml representation:

> `Foo | Bar` variants are stored as ascending OCaml ints, starting from 0

Re-use the existing Tag enum.