### PR TITLE
Optimize small_string_concat

### DIFF
--- a/compiler_tests.py
+++ b/compiler_tests.py
@@ -39,6 +39,9 @@ class CompilerEndToEndTests(unittest.TestCase):
     def test_small_string(self) -> None:
         self.assertEqual(self._run('"hello"'), '"hello"\n')
 
+    def test_small_string_concat(self) -> None:
+        self.assertEqual(self._run('"abc" ++ "def"'), '"abcdef"\n')
+
     def test_heap_string(self) -> None:
         self.assertEqual(self._run('"hello world"'), '"hello world"\n')
 


### PR DESCRIPTION
Goes from a assembly mess with SIMD and stuff to:

```
0000000000002070 <small_string_concat>:
  return (((uword)obj) >> kImmediateTagBits) & kMaxSmallStringLength;
    2070:	89 f8                	mov    eax,edi
    2072:	c1 e8 05             	shr    eax,0x5
    2075:	83 e0 07             	and    eax,0x7
  uword length = small_string_length(a_obj) + small_string_length(b_obj);
  uword result = ((uword)b_obj) & ~(uword)0xFFULL;
    2078:	48 89 f2             	mov    rdx,rsi
    207b:	48 81 e2 00 ff ff ff 	and    rdx,0xffffffffffffff00
  result <<= small_string_length(a_obj) * kBitsPerByte;
    2082:	89 c1                	mov    ecx,eax
    2084:	c1 e1 03             	shl    ecx,0x3
    2087:	48 d3 e2             	shl    rdx,cl
  result |= ((uword)a_obj) & ~(uword)0xFFULL;
    208a:	48 81 e7 00 ff ff ff 	and    rdi,0xffffffffffffff00
  result |= length << kImmediateTagBits;
    2091:	48 c1 e0 05          	shl    rax,0x5
    2095:	81 e6 e0 00 00 00    	and    esi,0xe0
    209b:	48 01 f0             	add    rax,rsi
    209e:	48 09 f8             	or     rax,rdi
  result |= kSmallStringTag;
    20a1:	48 09 d0             	or     rax,rdx
    20a4:	48 83 c8 0d          	or     rax,0xd
  struct object* result_obj = (struct object*)result;
  return result_obj;
    20a8:	c3                   	ret
```
