### PR TITLE
Verify shadow stack before and after collect

### DIFF
--- a/runtime.c
+++ b/runtime.c
@@ -226,8 +226,8 @@ void assert_in_heap(struct object** pointer, struct gc_heap* heap) {
     return;
   }
   if (!in_heap(heap, obj)) {
-    fprintf(stderr, "pointer %p not in heap [%p, %p)\n", obj, heap->to_space,
-            heap->hp);
+    fprintf(stderr, "pointer %p not in heap [%p, %p)\n", obj, (void*)heap->to_space,
+            (void*)heap->hp);
     abort();
   }
 }

--- a/runtime.c
+++ b/runtime.c
@@ -225,7 +225,11 @@ void assert_in_heap(struct object** pointer, struct gc_heap* heap) {
   if (in_const_heap(obj)) {
     return;
   }
-  assert(in_heap(heap, obj));
+  if (!in_heap(heap, obj)) {
+    fprintf(stderr, "pointer %p not in heap [%p, %p)\n", obj, heap->to_space,
+            heap->hp);
+    abort();
+  }
 }
 
 static NEVER_INLINE void heap_verify(struct gc_heap* heap) {

--- a/runtime.c
+++ b/runtime.c
@@ -228,6 +228,7 @@ void assert_in_heap(struct object** pointer, struct gc_heap* heap) {
 }
 
 static NEVER_INLINE void heap_verify(struct gc_heap* heap) {
+  trace_roots(heap, assert_in_heap);
   uintptr_t scan = heap->to_space;
   while (scan < heap->hp) {
     struct gc_obj* obj = (struct gc_obj*)scan;


### PR DESCRIPTION
- Also verify that the shadow stack points into the heap
- Scan from base of heap, not to/from space
- Use more expressive error
- When growing the heap, verify before swapping in new space
