### PR TITLE
Preserve source location information during parsing

### DIFF
--- a/scrapscript.py
+++ b/scrapscript.py
@@ -587,9 +587,7 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
         return make_source_annotated_object(
             MatchFunction,
             reduce(
-                lambda source_extent_one, source_extent_two: source_extent_one.coalesce(source_extent_two)
-                if source_extent_one
-                else None,
+                lambda source_extent_one, source_extent_two: join_source_extents(source_extent_one, source_extent_two),
                 cases_source_extents,
             ),
             cases,
@@ -671,9 +669,7 @@ def parse_binary(tokens: Peekable, p: float) -> "Object":
             if pl < p:
                 break
             arg = parse_binary(tokens, pr)
-            l = make_source_annotated_object(
-                Apply, l.source_extent.coalesce(arg.source_extent) if l.source_extent else None, l, arg
-            )
+            l = make_source_annotated_object(Apply, join_source_extents(l.source_extent, arg.source_extent), l, arg)
             continue
         prec = PS[op.value]
         pl, pr = prec.pl, prec.pr
@@ -685,29 +681,25 @@ def parse_binary(tokens: Peekable, p: float) -> "Object":
                 raise ParseError(f"expected variable in assignment {l!r}")
             value = parse_binary(tokens, pr)
             l = make_source_annotated_object(
-                Assign, l.source_extent.coalesce(value.source_extent) if l.source_extent else None, l, value
+                Assign, join_source_extents(l.source_extent, value.source_extent), l, value
             )
         elif op == Operator("->"):
             body = parse_binary(tokens, pr)
             l = make_source_annotated_object(
-                Function, l.source_extent.coalesce(body.source_extent) if l.source_extent else None, l, body
+                Function, join_source_extents(l.source_extent, body.source_extent), l, body
             )
         elif op == Operator("|>"):
             func = parse_binary(tokens, pr)
-            l = make_source_annotated_object(
-                Apply, func.source_extent.coalesce(l.source_extent) if func.source_extent else None, func, l
-            )
+            l = make_source_annotated_object(Apply, join_source_extents(func.source_extent, l.source_extent), func, l)
         elif op == Operator("<|"):
             arg = parse_binary(tokens, pr)
-            l = make_source_annotated_object(
-                Apply, l.source_extent.coalesce(arg.source_extent) if l.source_extent else None, l, arg
-            )
+            l = make_source_annotated_object(Apply, join_source_extents(l.source_extent, arg.source_extent), l, arg)
         elif op == Operator(">>"):
             r = parse_binary(tokens, pr)
             varname = gensym()
             l = make_source_annotated_object(
                 Function,
-                l.source_extent.coalesce(r.source_extent) if l.source_extent else None,
+                join_source_extents(l.source_extent, r.source_extent),
                 Var(varname),
                 Apply(r, Apply(l, Var(varname))),
             )
@@ -716,32 +708,28 @@ def parse_binary(tokens: Peekable, p: float) -> "Object":
             varname = gensym()
             l = make_source_annotated_object(
                 Function,
-                l.source_extent.coalesce(r.source_extent) if l.source_extent else None,
+                join_source_extents(l.source_extent, r.source_extent),
                 Var(varname),
                 Apply(l, Apply(r, Var(varname))),
             )
         elif op == Operator("."):
             binding = parse_binary(tokens, pr)
             l = make_source_annotated_object(
-                Where, l.source_extent.coalesce(binding.source_extent) if l.source_extent else None, l, binding
+                Where, join_source_extents(l.source_extent, binding.source_extent), l, binding
             )
         elif op == Operator("?"):
             cond = parse_binary(tokens, pr)
-            l = make_source_annotated_object(
-                Assert, l.source_extent.coalesce(cond.source_extent) if l.source_extent else None, l, cond
-            )
+            l = make_source_annotated_object(Assert, join_source_extents(l.source_extent, cond.source_extent), l, cond)
         elif op == Operator("@"):
             # TODO: revisit whether to use @ or . for field access
             at = parse_binary(tokens, pr)
-            l = make_source_annotated_object(
-                Access, l.source_extent.coalesce(at.source_extent) if l.source_extent else None, l, at
-            )
+            l = make_source_annotated_object(Access, join_source_extents(l.source_extent, at.source_extent), l, at)
         else:
             assert isinstance(op, Operator)
             right = parse_binary(tokens, pr)
             l = make_source_annotated_object(
                 Binop,
-                l.source_extent.coalesce(right.source_extent) if l.source_extent else None,
+                join_source_extents(l.source_extent, right.source_extent),
                 BinopKind.from_str(op.value),
                 l,
                 right,

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -506,18 +506,12 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
     l: Object
     new_r: Object
     if isinstance(token, IntLit):
-        l = Int(token.value)
-        l.source_extent = token.source_extent
-        return l
+        return make_source_annotated_object(Int, token.source_extent, token.value)
     elif isinstance(token, FloatLit):
-        l = Float(token.value)
-        l.source_extent = token.source_extent
-        return l
+        return make_source_annotated_object(Float, token.source_extent, token.value)
     elif isinstance(token, Name):
         # TODO: Handle kebab case vars
-        l = Var(token.value)
-        l.source_extent = token.source_extent
-        return l
+        return make_source_annotated_object(Var, token.source_extent, token.value)
     elif isinstance(token, Hash):
         if isinstance(variant_tag := next(tokens), Name):
             # It needs to be higher than the precedence of the -> operator so that
@@ -527,12 +521,12 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
             # It needs to be higher than the precedence of juxtaposition so that
             # f #true() #false() is parsed as f(TRUE)(FALSE)
             variant_payload = parse_binary(tokens, PS[""].pr + 1)
-            variant = Variant(
+            return make_source_annotated_object(
+                Variant,
+                variant_tag.source_extent.coalesce(variant_payload.source_extent),
                 variant_tag.value,
                 variant_payload,
             )
-            variant.source_extent = variant_tag.source_extent.coalesce(variant_payload.source_extent)
-            return variant
         else:
             raise UnexpectedTokenError(variant_tag)
     elif isinstance(token, BytesLit):
@@ -550,20 +544,16 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
         l.source_extent = token.source_extent
         return l
     elif isinstance(token, StringLit):
-        string = String(token.value)
-        string.source_extent = token.source_extent
-        return string
+        return make_source_annotated_object(String, token.source_extent, token.value)
     elif token == Operator("..."):
         try:
             if isinstance(tokens.peek(), Name):
                 spread_variable = next(tokens)
-                spread = Spread(spread_variable.value)
-                spread.source_extent = token.source_extent.coalesce(spread_variable.source_extent)
-                return spread
+                return make_source_annotated_object(
+                    Spread, token.source_extent.coalesce(spread_variable.source_extent), spread_variable.value
+                )
             else:
-                spread = Spread()
-                spread.source_extent = token.source_extent
-                return spread
+                return make_source_annotated_object(Spread, token.source_extent)
         except StopIteration:
             return Spread()
     elif token == Operator("|"):
@@ -571,8 +561,9 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
         expr = parse_binary(tokens, PS["|"].pr)  # TODO: make this work for larger arities
         if not isinstance(expr, Function):
             raise ParseError(f"expected function in match expression {expr!r}")
-        match_case = MatchCase(expr.arg, expr.body)
-        match_case.source_extent = pipe_source_extent.coalesce(expr.source_extent)
+        match_case = make_source_annotated_object(
+            MatchCase, pipe_source_extent.coalesce(expr.source_extent), expr.arg, expr.body
+        )
         cases = [match_case]
         while True:
             try:
@@ -584,18 +575,25 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
             expr = parse_binary(tokens, PS["|"].pr)  # TODO: make this work for larger arities
             if not isinstance(expr, Function):
                 raise ParseError(f"expected function in match expression {expr!r}")
-            match_case = MatchCase(expr.arg, expr.body)
-            match_case.source_extent = pipe_source_extent.coalesce(expr.source_extent)
+            match_case = make_source_annotated_object(
+                MatchCase, pipe_source_extent.coalesce(expr.source_extent), expr.arg, expr.body
+            )
             cases.append(match_case)
         cases_source_extents = [case_branch.source_extent for case_branch in cases]
-        match_function = MatchFunction(cases)
-        match_function.source_extent = reduce(lambda c1, c2: c1.coalesce(c2) if c1 else None, cases_source_extents)
-        return match_function
+        return make_source_annotated_object(
+            MatchFunction,
+            reduce(
+                lambda source_extent_one, source_extent_two: source_extent_one.coalesce(source_extent_two)
+                if source_extent_one
+                else None,
+                cases_source_extents,
+            ),
+            cases,
+        )
     elif isinstance(token, LeftParen):
         left_paren_source_extent = token.source_extent
         if isinstance(tokens.peek(), RightParen):
-            l = Hole()
-            l.source_extent = left_paren_source_extent.coalesce(next(tokens).source_extent)
+            l = make_source_annotated_object(Hole, left_paren_source_extent.coalesce(next(tokens).source_extent))
         else:
             l = parse(tokens)
             next(tokens)
@@ -644,14 +642,10 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
         source_extent = token.source_extent.coalesce(r.source_extent)
         if isinstance(r, Int):
             assert r.value >= 0, "Tokens should never have negative values"
-            new_r = Int(-r.value)
-            new_r.source_extent = source_extent
-            return new_r
+            return make_source_annotated_object(Int, source_extent, -r.value)
         if isinstance(r, Float):
             assert r.value >= 0, "Tokens should never have negative values"
-            new_r = Float(-r.value)
-            new_r.source_extent = source_extent
-            return new_r
+            return make_source_annotated_object(Float, source_extent, -r.value)
         binop = Binop(BinopKind.SUB, Int(0), r)
         binop.source_extent = source_extent
         return binop
@@ -689,58 +683,68 @@ def parse_binary(tokens: Peekable, p: float) -> "Object":
             if not isinstance(l, Var):
                 raise ParseError(f"expected variable in assignment {l!r}")
             value = parse_binary(tokens, pr)
-            new_l = Assign(l, value)
-            new_l.source_extent = l.source_extent.coalesce(value.source_extent) if l.source_extent else None
-            l = new_l
+            l = make_source_annotated_object(
+                Assign, l.source_extent.coalesce(value.source_extent) if l.source_extent else None, l, value
+            )
         elif op == Operator("->"):
             body = parse_binary(tokens, pr)
-            new_l = Function(l, body)
-            new_l.source_extent = l.source_extent.coalesce(body.source_extent) if l.source_extent else None
-            l = new_l
+            l = make_source_annotated_object(
+                Function, l.source_extent.coalesce(body.source_extent) if l.source_extent else None, l, body
+            )
         elif op == Operator("|>"):
             func = parse_binary(tokens, pr)
-            new_l = Apply(func, l)
-            new_l.source_extent = func.source_extent.coalesce(l.source_extent) if func.source_extent else None
-            l = new_l
+            l = make_source_annotated_object(
+                Apply, func.source_extent.coalesce(l.source_extent) if func.source_extent else None, func, l
+            )
         elif op == Operator("<|"):
             arg = parse_binary(tokens, pr)
-            new_l = Apply(l, arg)
-            new_l.source_extent = l.source_extent.coalesce(arg.source_extent) if l.source_extent else None
-            l = new_l
+            l = make_source_annotated_object(
+                Apply, l.source_extent.coalesce(arg.source_extent) if l.source_extent else None, l, arg
+            )
         elif op == Operator(">>"):
             r = parse_binary(tokens, pr)
             varname = gensym()
-            new_l = Function(Var(varname), Apply(r, Apply(l, Var(varname))))
-            new_l.source_extent = l.source_extent.coalesce(r.source_extent) if l.source_extent else None
-            l = new_l
+            l = make_source_annotated_object(
+                Function,
+                l.source_extent.coalesce(r.source_extent) if l.source_extent else None,
+                Var(varname),
+                Apply(r, Apply(l, Var(varname))),
+            )
         elif op == Operator("<<"):
             r = parse_binary(tokens, pr)
             varname = gensym()
-            new_l = Function(Var(varname), Apply(l, Apply(r, Var(varname))))
-            new_l.source_extent = l.source_extent.coalesce(r.source_extent) if l.source_extent else None
-            l = new_l
+            l = make_source_annotated_object(
+                Function,
+                l.source_extent.coalesce(r.source_extent) if l.source_extent else None,
+                Var(varname),
+                Apply(l, Apply(r, Var(varname))),
+            )
         elif op == Operator("."):
             binding = parse_binary(tokens, pr)
-            new_l = Where(l, binding)
-            new_l.source_extent = l.source_extent.coalesce(binding.source_extent) if l.source_extent else None
-            l = new_l
+            l = make_source_annotated_object(
+                Where, l.source_extent.coalesce(binding.source_extent) if l.source_extent else None, l, binding
+            )
         elif op == Operator("?"):
             cond = parse_binary(tokens, pr)
-            new_l = Assert(l, cond)
-            new_l.source_extent = l.source_extent.coalesce(cond.source_extent) if l.source_extent else None
-            l = new_l
+            l = make_source_annotated_object(
+                Assert, l.source_extent.coalesce(cond.source_extent) if l.source_extent else None, l, cond
+            )
         elif op == Operator("@"):
             # TODO: revisit whether to use @ or . for field access
             at = parse_binary(tokens, pr)
-            new_l = Access(l, at)
-            new_l.source_extent = l.source_extent.coalesce(at.source_extent) if l.source_extent else None
-            l = new_l
+            l = make_source_annotated_object(
+                Access, l.source_extent.coalesce(at.source_extent) if l.source_extent else None, l, at
+            )
         else:
             assert isinstance(op, Operator)
             right = parse_binary(tokens, pr)
-            new_l = Binop(BinopKind.from_str(op.value), l, right)
-            new_l.source_extent = l.source_extent.coalesce(right.source_extent) if l.source_extent else None
-            l = new_l
+            l = make_source_annotated_object(
+                Binop,
+                l.source_extent.coalesce(right.source_extent) if l.source_extent else None,
+                BinopKind.from_str(op.value),
+                l,
+                right,
+            )
     return l
 
 

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -823,6 +823,7 @@ class Spread(Object):
 Env = Mapping[str, Object]
 
 
+# TODO(max): Add source extents for BinopKind?
 class BinopKind(enum.Enum):
     ADD = auto()
     SUB = auto()

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -496,7 +496,7 @@ gensym_reset()
 
 def make_source_annotated_object(cls: type, source_extent: Optional[SourceExtent], *args: Any) -> Object:
     result: Object = cls(*args)
-    result.source_extent = source_extent
+    object.__setattr__(result, "source_extent", source_extent)
     return result
 
 
@@ -539,7 +539,7 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
             l = Bytes(base64.b16decode(token.value))
         else:
             raise ParseError(f"unexpected base {base!r} in {token!r}")
-        l.source_extent = token.source_extent
+        object.__setattr__(l, "source_extent", token.source_extent)
         return l
     elif isinstance(token, StringLit):
         return make_source_annotated_object(String, token.source_extent, token.value)
@@ -610,7 +610,7 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
                 # TODO: Implement .. operator
                 l.items.append(parse_binary(tokens, 2))
             list_end_source_extent = token.source_extent
-        l.source_extent = list_start_source_extent.coalesce(list_end_source_extent)
+        object.__setattr__(l, "source_extent", list_start_source_extent.coalesce(list_end_source_extent))
         return l
     elif isinstance(token, LeftBrace):
         record_start_source_extent = token.source_extent
@@ -628,7 +628,7 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
                 assign = parse_assign(tokens, 2)
                 l.data[assign.name.name] = assign.value
             record_end_source_extent = token.source_extent
-        l.source_extent = record_start_source_extent.coalesce(record_end_source_extent)
+        object.__setattr__(l, "source_extent", record_start_source_extent.coalesce(record_end_source_extent))
         return l
     elif token == Operator("-"):
         # Unary minus
@@ -750,7 +750,7 @@ def parse(tokens: Peekable) -> "Object":
         raise UnexpectedEOFError("unexpected end of input")
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Object:
     source_extent: Optional[SourceExtent] = dataclasses.field(default=None, compare=False, init=False, repr=False)
 
@@ -762,7 +762,7 @@ class Object:
         pass
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Int(Object):
     value: int
 
@@ -771,7 +771,7 @@ class Int(Object):
         return isinstance(other, Int) and self == other and self.source_extent == other.source_extent
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Float(Object):
     value: float
 
@@ -780,7 +780,7 @@ class Float(Object):
         return isinstance(other, Float) and self == other and self.source_extent == other.source_extent
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class String(Object):
     value: str
 
@@ -789,7 +789,7 @@ class String(Object):
         return isinstance(other, String) and self == other and self.source_extent == other.source_extent
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Bytes(Object):
     value: bytes
 
@@ -798,7 +798,7 @@ class Bytes(Object):
         return isinstance(other, Bytes) and self == other and self.source_extent == other.source_extent
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Var(Object):
     name: str
 
@@ -807,7 +807,7 @@ class Var(Object):
         return isinstance(other, Var) and self == other and self.source_extent == other.source_extent
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Hole(Object):
     pass
 
@@ -816,7 +816,7 @@ class Hole(Object):
         return isinstance(other, Hole) and self.source_extent == other.source_extent
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Spread(Object):
     name: Optional[str] = None
 
@@ -907,7 +907,7 @@ class BinopKind(enum.Enum):
         }[binop_kind]
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Binop(Object):
     op: BinopKind
     left: Object
@@ -924,7 +924,7 @@ class Binop(Object):
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class List(Object):
     items: typing.List[Object]
 
@@ -938,7 +938,7 @@ class List(Object):
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Assign(Object):
     name: Var
     value: Object
@@ -954,7 +954,7 @@ class Assign(Object):
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Function(Object):
     arg: Object
     body: Object
@@ -970,7 +970,7 @@ class Function(Object):
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Apply(Object):
     func: Object
     arg: Object
@@ -986,7 +986,7 @@ class Apply(Object):
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Where(Object):
     body: Object
     binding: Object
@@ -1002,7 +1002,7 @@ class Where(Object):
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Assert(Object):
     value: Object
     cond: Object
@@ -1018,7 +1018,7 @@ class Assert(Object):
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class EnvObject(Object):
     env: Env
 
@@ -1030,7 +1030,7 @@ class EnvObject(Object):
         return f"EnvObject(keys={self.env.keys()})"
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class MatchCase(Object):
     pattern: Object
     body: Object
@@ -1046,7 +1046,7 @@ class MatchCase(Object):
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class MatchFunction(Object):
     cases: typing.List[MatchCase]
 
@@ -1063,7 +1063,7 @@ class MatchFunction(Object):
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Relocation(Object):
     name: str
 
@@ -1072,14 +1072,14 @@ class Relocation(Object):
         return isinstance(other, Relocation) and self == other and self.source_extent == other.source_extent
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class NativeFunctionRelocation(Relocation):
     @override
     def source_equals(self, other: Object) -> bool:
         return isinstance(other, NativeFunctionRelocation) and self.source_extent == other.source_extent
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class NativeFunction(Object):
     name: str
     func: Callable[[Object], Object]
@@ -1089,7 +1089,7 @@ class NativeFunction(Object):
         return isinstance(other, NativeFunction) and self == other and self.source_extent == other.source_extent
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Closure(Object):
     env: Env
     func: Union[Function, MatchFunction]
@@ -1104,7 +1104,7 @@ class Closure(Object):
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Record(Object):
     data: Dict[str, Object]
 
@@ -1120,7 +1120,7 @@ class Record(Object):
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Access(Object):
     obj: Object
     at: Object
@@ -1136,7 +1136,7 @@ class Access(Object):
         )
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Variant(Object):
     tag: str
     value: Object

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -13,13 +13,11 @@ import struct
 import sys
 import typing
 import urllib.request
-from abc import abstractmethod
 from dataclasses import dataclass
 from enum import auto
 from functools import reduce
 from types import ModuleType
 from typing import Any, Callable, Dict, Generator, Iterator, Mapping, Optional, Set, Tuple, Union
-from typing_extensions import override
 
 readline: Optional[ModuleType]
 try:
@@ -751,72 +749,40 @@ class Object:
     def __str__(self) -> str:
         return pretty(self)
 
-    @abstractmethod
-    def source_equals(self, other: Object) -> bool:
-        pass
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Int(Object):
     value: int
-
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return isinstance(other, Int) and self == other and self.source_extent == other.source_extent
 
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Float(Object):
     value: float
 
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return isinstance(other, Float) and self == other and self.source_extent == other.source_extent
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class String(Object):
     value: str
-
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return isinstance(other, String) and self == other and self.source_extent == other.source_extent
 
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Bytes(Object):
     value: bytes
 
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return isinstance(other, Bytes) and self == other and self.source_extent == other.source_extent
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Var(Object):
     name: str
-
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return isinstance(other, Var) and self == other and self.source_extent == other.source_extent
 
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Hole(Object):
     pass
 
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return isinstance(other, Hole) and self.source_extent == other.source_extent
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Spread(Object):
     name: Optional[str] = None
-
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return isinstance(other, Spread) and self == other and self.source_extent == other.source_extent
 
 
 Env = Mapping[str, Object]
@@ -907,29 +873,10 @@ class Binop(Object):
     left: Object
     right: Object
 
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, Binop)
-            and self == other
-            and self.source_extent == other.source_extent
-            and self.left.source_equals(other.left)
-            and self.right.source_equals(other.right)
-        )
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class List(Object):
     items: typing.List[Object]
-
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, List)
-            and self == other
-            and self.source_extent == other.source_extent
-            and all(item.source_equals(other_item) for item, other_item in zip(self.items, other.items))
-        )
 
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
@@ -937,31 +884,11 @@ class Assign(Object):
     name: Var
     value: Object
 
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, Assign)
-            and self == other
-            and self.source_extent == other.source_extent
-            and self.name.source_equals(other.name)
-            and self.value.source_equals(other.value)
-        )
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Function(Object):
     arg: Object
     body: Object
-
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, Function)
-            and self == other
-            and self.source_extent == other.source_extent
-            and self.arg.source_equals(other.arg)
-            and self.body.source_equals(other.body)
-        )
 
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
@@ -969,31 +896,11 @@ class Apply(Object):
     func: Object
     arg: Object
 
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, Apply)
-            and self == other
-            and self.source_extent == other.source_extent
-            and self.func.source_equals(other.func)
-            and self.arg.source_equals(other.arg)
-        )
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Where(Object):
     body: Object
     binding: Object
-
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, Where)
-            and self == other
-            and self.source_extent == other.source_extent
-            and self.body.source_equals(other.body)
-            and self.binding.source_equals(other.binding)
-        )
 
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
@@ -1001,24 +908,10 @@ class Assert(Object):
     value: Object
     cond: Object
 
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, Assert)
-            and self == other
-            and self.source_extent == other.source_extent
-            and self.value.source_equals(other.value)
-            and self.cond.source_equals(other.cond)
-        )
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class EnvObject(Object):
     env: Env
-
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return isinstance(other, EnvObject) and self == other and self.source_extent == other.source_extent
 
     def __str__(self) -> str:
         return f"EnvObject(keys={self.env.keys()})"
@@ -1029,48 +922,20 @@ class MatchCase(Object):
     pattern: Object
     body: Object
 
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, MatchCase)
-            and self == other
-            and self.source_extent == other.source_extent
-            and self.pattern.source_equals(other.pattern)
-            and self.body.source_equals(other.body)
-        )
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class MatchFunction(Object):
     cases: typing.List[MatchCase]
-
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, MatchFunction)
-            and self == other
-            and self.source_extent == other.source_extent
-            and all(
-                match_case.source_equals(other_match_case)
-                for match_case, other_match_case in zip(self.cases, other.cases)
-            )
-        )
 
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Relocation(Object):
     name: str
 
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return isinstance(other, Relocation) and self == other and self.source_extent == other.source_extent
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class NativeFunctionRelocation(Relocation):
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return isinstance(other, NativeFunctionRelocation) and self.source_extent == other.source_extent
+    pass
 
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
@@ -1078,40 +943,16 @@ class NativeFunction(Object):
     name: str
     func: Callable[[Object], Object]
 
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return isinstance(other, NativeFunction) and self == other and self.source_extent == other.source_extent
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Closure(Object):
     env: Env
     func: Union[Function, MatchFunction]
 
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, Closure)
-            and self == other
-            and self.source_extent == other.source_extent
-            and self.func.source_equals(other.func)
-        )
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Record(Object):
     data: Dict[str, Object]
-
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, Record)
-            and self == other
-            and self.source_extent == other.source_extent
-            and all(
-                self.data[k1].source_equals(other.data[k2]) for k1, k2 in zip(sorted(self.data), sorted(other.data))
-            )
-        )
 
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
@@ -1119,30 +960,11 @@ class Access(Object):
     obj: Object
     at: Object
 
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, Access)
-            and self == other
-            and self.source_extent == other.source_extent
-            and self.obj.source_equals(other.obj)
-            and self.at.source_equals(other.at)
-        )
-
 
 @dataclass(eq=True, frozen=True, unsafe_hash=True)
 class Variant(Object):
     tag: str
     value: Object
-
-    @override
-    def source_equals(self, other: Object) -> bool:
-        return (
-            isinstance(other, Variant)
-            and self == other
-            and self.source_extent == other.source_extent
-            and self.value.source_equals(other.value)
-        )
 
 
 tags = [

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -15,6 +15,7 @@ import typing
 import urllib.request
 from dataclasses import dataclass
 from enum import auto
+from functools import reduce
 from types import ModuleType
 from typing import Any, Callable, Dict, Generator, Iterator, Mapping, Optional, Set, Tuple, Union
 
@@ -32,7 +33,7 @@ def is_identifier_char(c: str) -> bool:
     return c.isalnum() or c in ("$", "'", "_")
 
 
-@dataclass(eq=True, unsafe_hash=True)
+@dataclass(eq=True, order=True, unsafe_hash=True)
 class SourceLocation:
     lineno: int = dataclasses.field(default=-1)
     colno: int = dataclasses.field(default=-1)
@@ -43,6 +44,9 @@ class SourceLocation:
 class SourceExtent:
     start: SourceLocation = dataclasses.field(default_factory=SourceLocation)
     end: SourceLocation = dataclasses.field(default_factory=SourceLocation)
+
+    def coalesce(self, other: Optional[SourceExtent]) -> Optional[SourceExtent]:
+        return SourceExtent(min(self.start, other.start), max(self.end, other.end)) if other else None
 
 
 @dataclass(eq=True)
@@ -491,24 +495,37 @@ gensym_reset()
 def parse_unary(tokens: Peekable, p: float) -> "Object":
     token = next(tokens)
     l: Object
+    new_r: Object
     if isinstance(token, IntLit):
-        return Int(token.value)
+        l = Int(token.value)
+        l.source_extent = token.source_extent
+        return l
     elif isinstance(token, FloatLit):
-        return Float(token.value)
+        l = Float(token.value)
+        l.source_extent = token.source_extent
+        return l
     elif isinstance(token, Name):
         # TODO: Handle kebab case vars
-        return Var(token.value)
+        l = Var(token.value)
+        l.source_extent = token.source_extent
+        return l
     elif isinstance(token, Hash):
-        if isinstance(variant := next(tokens), Name):
+        if isinstance(variant_tag := next(tokens), Name):
             # It needs to be higher than the precedence of the -> operator so that
             # we can match variants in MatchFunction
             # It needs to be higher than the precedence of the && operator so that
             # we can use #true() and #false() in boolean expressions
             # It needs to be higher than the precedence of juxtaposition so that
             # f #true() #false() is parsed as f(TRUE)(FALSE)
-            return Variant(variant.value, parse_binary(tokens, PS[""].pr + 1))
+            variant_payload = parse_binary(tokens, PS[""].pr + 1)
+            variant = Variant(
+                variant_tag.value,
+                variant_payload,
+            )
+            variant.source_extent = variant_tag.source_extent.coalesce(variant_payload.source_extent)
+            return variant
         else:
-            raise UnexpectedTokenError(variant)
+            raise UnexpectedTokenError(variant_tag)
     elif isinstance(token, BytesLit):
         base = token.base
         if base == 85:
@@ -521,68 +538,92 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
             l = Bytes(base64.b16decode(token.value))
         else:
             raise ParseError(f"unexpected base {base!r} in {token!r}")
+        l.source_extent = token.source_extent
         return l
     elif isinstance(token, StringLit):
-        return String(token.value)
+        string = String(token.value)
+        string.source_extent = token.source_extent
+        return string
     elif token == Operator("..."):
         try:
             if isinstance(tokens.peek(), Name):
-                return Spread(next(tokens).value)
+                spread_variable = next(tokens)
+                spread = Spread(spread_variable.value)
+                spread.source_extent = token.source_extent.coalesce(spread_variable.source_extent)
+                return spread
             else:
-                return Spread()
+                spread = Spread()
+                spread.source_extent = token.source_extent
+                return spread
         except StopIteration:
             return Spread()
     elif token == Operator("|"):
+        pipe_source_extent = token.source_extent
         expr = parse_binary(tokens, PS["|"].pr)  # TODO: make this work for larger arities
         if not isinstance(expr, Function):
             raise ParseError(f"expected function in match expression {expr!r}")
-        cases = [MatchCase(expr.arg, expr.body)]
+        match_case = MatchCase(expr.arg, expr.body)
+        match_case.source_extent = pipe_source_extent.coalesce(expr.source_extent)
+        cases = [match_case]
         while True:
             try:
                 if tokens.peek() != Operator("|"):
                     break
             except StopIteration:
                 break
-            next(tokens)
+            pipe_source_extent = next(tokens).source_extent
             expr = parse_binary(tokens, PS["|"].pr)  # TODO: make this work for larger arities
             if not isinstance(expr, Function):
                 raise ParseError(f"expected function in match expression {expr!r}")
-            cases.append(MatchCase(expr.arg, expr.body))
-        return MatchFunction(cases)
+            match_case = MatchCase(expr.arg, expr.body)
+            match_case.source_extent = pipe_source_extent.coalesce(expr.source_extent)
+            cases.append(match_case)
+        cases_source_extents = [case_branch.source_extent for case_branch in cases]
+        match_function = MatchFunction(cases)
+        match_function.source_extent = reduce(lambda c1, c2: c1.coalesce(c2) if c1 else None, cases_source_extents)
+        return match_function
     elif isinstance(token, LeftParen):
+        left_paren_source_extent = token.source_extent
         if isinstance(tokens.peek(), RightParen):
             l = Hole()
+            l.source_extent = left_paren_source_extent.coalesce(next(tokens).source_extent)
         else:
             l = parse(tokens)
-        next(tokens)
+            next(tokens)
         return l
     elif isinstance(token, LeftBracket):
+        list_start_source_extent = token.source_extent
         l = List([])
         token = tokens.peek()
         if isinstance(token, RightBracket):
-            next(tokens)
+            list_end_source_extent = next(tokens).source_extent
         else:
             l.items.append(parse_binary(tokens, 2))
-            while not isinstance(next(tokens), RightBracket):
+            while not isinstance(token := next(tokens), RightBracket):
                 if isinstance(l.items[-1], Spread):
                     raise ParseError("spread must come at end of list match")
                 # TODO: Implement .. operator
                 l.items.append(parse_binary(tokens, 2))
+            list_end_source_extent = token.source_extent
+        l.source_extent = list_start_source_extent.coalesce(list_end_source_extent)
         return l
     elif isinstance(token, LeftBrace):
+        record_start_source_extent = token.source_extent
         l = Record({})
         token = tokens.peek()
         if isinstance(token, RightBrace):
-            next(tokens)
+            record_end_source_extent = next(tokens).source_extent
         else:
             assign = parse_assign(tokens, 2)
             l.data[assign.name.name] = assign.value
-            while not isinstance(next(tokens), RightBrace):
+            while not isinstance(token := next(tokens), RightBrace):
                 if isinstance(assign.value, Spread):
                     raise ParseError("spread must come at end of record match")
                 # TODO: Implement .. operator
                 assign = parse_assign(tokens, 2)
                 l.data[assign.name.name] = assign.value
+            record_end_source_extent = token.source_extent
+        l.source_extent = record_start_source_extent.coalesce(record_end_source_extent)
         return l
     elif token == Operator("-"):
         # Unary minus
@@ -591,19 +632,27 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
         # Precedence was chosen to be higher than function application so that
         # -a b is (-a) b and not -(a b).
         r = parse_binary(tokens, HIGHEST_PREC + 1)
+        source_extent = token.source_extent.coalesce(r.source_extent)
         if isinstance(r, Int):
             assert r.value >= 0, "Tokens should never have negative values"
-            return Int(-r.value)
+            new_r = Int(-r.value)
+            new_r.source_extent = source_extent
+            return new_r
         if isinstance(r, Float):
             assert r.value >= 0, "Tokens should never have negative values"
-            return Float(-r.value)
-        return Binop(BinopKind.SUB, Int(0), r)
+            new_r = Float(-r.value)
+            new_r.source_extent = source_extent
+            return new_r
+        binop = Binop(BinopKind.SUB, Int(0), r)
+        binop.source_extent = source_extent
+        return binop
     else:
         raise UnexpectedTokenError(token)
 
 
 def parse_binary(tokens: Peekable, p: float) -> "Object":
     l: Object = parse_unary(tokens, p)
+    new_l: Object
     while True:
         op: Token
         try:
@@ -617,7 +666,10 @@ def parse_binary(tokens: Peekable, p: float) -> "Object":
             pl, pr = prec.pl, prec.pr
             if pl < p:
                 break
-            l = Apply(l, parse_binary(tokens, pr))
+            arg = parse_binary(tokens, pr)
+            new_l = Apply(l, arg)
+            new_l.source_extent = l.source_extent.coalesce(arg.source_extent) if l.source_extent else None
+            l = new_l
             continue
         prec = PS[op.value]
         pl, pr = prec.pl, prec.pr
@@ -627,31 +679,59 @@ def parse_binary(tokens: Peekable, p: float) -> "Object":
         if op == Operator("="):
             if not isinstance(l, Var):
                 raise ParseError(f"expected variable in assignment {l!r}")
-            l = Assign(l, parse_binary(tokens, pr))
+            value = parse_binary(tokens, pr)
+            new_l = Assign(l, value)
+            new_l.source_extent = l.source_extent.coalesce(value.source_extent) if l.source_extent else None
+            l = new_l
         elif op == Operator("->"):
-            l = Function(l, parse_binary(tokens, pr))
+            body = parse_binary(tokens, pr)
+            new_l = Function(l, body)
+            new_l.source_extent = l.source_extent.coalesce(body.source_extent) if l.source_extent else None
+            l = new_l
         elif op == Operator("|>"):
-            l = Apply(parse_binary(tokens, pr), l)
+            func = parse_binary(tokens, pr)
+            new_l = Apply(func, l)
+            new_l.source_extent = func.source_extent.coalesce(l.source_extent) if func.source_extent else None
+            l = new_l
         elif op == Operator("<|"):
-            l = Apply(l, parse_binary(tokens, pr))
+            arg = parse_binary(tokens, pr)
+            new_l = Apply(l, arg)
+            new_l.source_extent = l.source_extent.coalesce(arg.source_extent) if l.source_extent else None
+            l = new_l
         elif op == Operator(">>"):
             r = parse_binary(tokens, pr)
             varname = gensym()
-            l = Function(Var(varname), Apply(r, Apply(l, Var(varname))))
+            new_l = Function(Var(varname), Apply(r, Apply(l, Var(varname))))
+            new_l.source_extent = l.source_extent.coalesce(r.source_extent) if l.source_extent else None
+            l = new_l
         elif op == Operator("<<"):
             r = parse_binary(tokens, pr)
             varname = gensym()
-            l = Function(Var(varname), Apply(l, Apply(r, Var(varname))))
+            new_l = Function(Var(varname), Apply(l, Apply(r, Var(varname))))
+            new_l.source_extent = l.source_extent.coalesce(r.source_extent) if l.source_extent else None
+            l = new_l
         elif op == Operator("."):
-            l = Where(l, parse_binary(tokens, pr))
+            binding = parse_binary(tokens, pr)
+            new_l = Where(l, binding)
+            new_l.source_extent = l.source_extent.coalesce(binding.source_extent) if l.source_extent else None
+            l = new_l
         elif op == Operator("?"):
-            l = Assert(l, parse_binary(tokens, pr))
+            cond = parse_binary(tokens, pr)
+            new_l = Assert(l, cond)
+            new_l.source_extent = l.source_extent.coalesce(cond.source_extent) if l.source_extent else None
+            l = new_l
         elif op == Operator("@"):
             # TODO: revisit whether to use @ or . for field access
-            l = Access(l, parse_binary(tokens, pr))
+            at = parse_binary(tokens, pr)
+            new_l = Access(l, at)
+            new_l.source_extent = l.source_extent.coalesce(at.source_extent) if l.source_extent else None
+            l = new_l
         else:
             assert isinstance(op, Operator)
-            l = Binop(BinopKind.from_str(op.value), l, parse_binary(tokens, pr))
+            right = parse_binary(tokens, pr)
+            new_l = Binop(BinopKind.from_str(op.value), l, right)
+            new_l.source_extent = l.source_extent.coalesce(right.source_extent) if l.source_extent else None
+            l = new_l
     return l
 
 
@@ -662,43 +742,45 @@ def parse(tokens: Peekable) -> "Object":
         raise UnexpectedEOFError("unexpected end of input")
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Object:
+    source_extent: Optional[SourceExtent] = dataclasses.field(default=None, compare=False, init=False, repr=False)
+
     def __str__(self) -> str:
         return pretty(self)
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Int(Object):
     value: int
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Float(Object):
     value: float
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class String(Object):
     value: str
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Bytes(Object):
     value: bytes
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Var(Object):
     name: str
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Hole(Object):
     pass
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Spread(Object):
     name: Optional[str] = None
 
@@ -784,49 +866,49 @@ class BinopKind(enum.Enum):
         }[binop_kind]
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Binop(Object):
     op: BinopKind
     left: Object
     right: Object
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class List(Object):
     items: typing.List[Object]
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Assign(Object):
     name: Var
     value: Object
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Function(Object):
     arg: Object
     body: Object
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Apply(Object):
     func: Object
     arg: Object
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Where(Object):
     body: Object
     binding: Object
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Assert(Object):
     value: Object
     cond: Object
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class EnvObject(Object):
     env: Env
 
@@ -834,51 +916,51 @@ class EnvObject(Object):
         return f"EnvObject(keys={self.env.keys()})"
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class MatchCase(Object):
     pattern: Object
     body: Object
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class MatchFunction(Object):
     cases: typing.List[MatchCase]
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Relocation(Object):
     name: str
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class NativeFunctionRelocation(Relocation):
     pass
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class NativeFunction(Object):
     name: str
     func: Callable[[Object], Object]
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Closure(Object):
     env: Env
     func: Union[Function, MatchFunction]
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Record(Object):
     data: Dict[str, Object]
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Access(Object):
     obj: Object
     at: Object
 
 
-@dataclass(eq=True, frozen=True, unsafe_hash=True)
+@dataclass(eq=True, unsafe_hash=True)
 class Variant(Object):
     tag: str
     value: Object

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -515,6 +515,7 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
         # TODO: Handle kebab case vars
         return make_source_annotated_object(Var, token.source_extent, token.value)
     elif isinstance(token, Hash):
+        hash_source_extent = token.source_extent
         if isinstance(variant_tag := next(tokens), Name):
             # It needs to be higher than the precedence of the -> operator so that
             # we can match variants in MatchFunction
@@ -525,7 +526,7 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
             variant_payload = parse_binary(tokens, PS[""].pr + 1)
             return make_source_annotated_object(
                 Variant,
-                variant_tag.source_extent.coalesce(variant_payload.source_extent),
+                hash_source_extent.coalesce(variant_payload.source_extent),
                 variant_tag.value,
                 variant_payload,
             )

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3.10
 from __future__ import annotations
+import abc
 import argparse
 import base64
 import code
@@ -13,11 +14,13 @@ import struct
 import sys
 import typing
 import urllib.request
+from abc import abstractmethod
 from dataclasses import dataclass
 from enum import auto
 from functools import reduce
 from types import ModuleType
 from typing import Any, Callable, Dict, Generator, Iterator, Mapping, Optional, Set, Tuple, Union
+from typing_extensions import override
 
 readline: Optional[ModuleType]
 try:
@@ -749,40 +752,72 @@ class Object:
     def __str__(self) -> str:
         return pretty(self)
 
+    @abstractmethod
+    def source_equals(self, other: Object) -> bool:
+        pass
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class Int(Object):
     value: int
+
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return isinstance(other, Int) and self == other and self.source_extent == other.source_extent
 
 
 @dataclass(eq=True, unsafe_hash=True)
 class Float(Object):
     value: float
 
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return isinstance(other, Float) and self == other and self.source_extent == other.source_extent
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class String(Object):
     value: str
+
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return isinstance(other, String) and self == other and self.source_extent == other.source_extent
 
 
 @dataclass(eq=True, unsafe_hash=True)
 class Bytes(Object):
     value: bytes
 
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return isinstance(other, Bytes) and self == other and self.source_extent == other.source_extent
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class Var(Object):
     name: str
+
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return isinstance(other, Var) and self == other and self.source_extent == other.source_extent
 
 
 @dataclass(eq=True, unsafe_hash=True)
 class Hole(Object):
     pass
 
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return isinstance(other, Hole) and self.source_extent == other.source_extent
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class Spread(Object):
     name: Optional[str] = None
+
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return isinstance(other, Spread) and self == other and self.source_extent == other.source_extent
 
 
 Env = Mapping[str, Object]
@@ -872,10 +907,29 @@ class Binop(Object):
     left: Object
     right: Object
 
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, Binop)
+            and self == other
+            and self.source_extent == other.source_extent
+            and self.left.source_equals(other.left)
+            and self.right.source_equals(other.right)
+        )
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class List(Object):
     items: typing.List[Object]
+
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, List)
+            and self == other
+            and self.source_extent == other.source_extent
+            and all(item.source_equals(other_item) for item, other_item in zip(self.items, other.items))
+        )
 
 
 @dataclass(eq=True, unsafe_hash=True)
@@ -883,11 +937,31 @@ class Assign(Object):
     name: Var
     value: Object
 
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, Assign)
+            and self == other
+            and self.source_extent == other.source_extent
+            and self.name.source_equals(other.name)
+            and self.value.source_equals(other.value)
+        )
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class Function(Object):
     arg: Object
     body: Object
+
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, Function)
+            and self == other
+            and self.source_extent == other.source_extent
+            and self.arg.source_equals(other.arg)
+            and self.body.source_equals(other.body)
+        )
 
 
 @dataclass(eq=True, unsafe_hash=True)
@@ -895,11 +969,31 @@ class Apply(Object):
     func: Object
     arg: Object
 
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, Apply)
+            and self == other
+            and self.source_extent == other.source_extent
+            and self.func.source_equals(other.func)
+            and self.arg.source_equals(other.arg)
+        )
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class Where(Object):
     body: Object
     binding: Object
+
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, Where)
+            and self == other
+            and self.source_extent == other.source_extent
+            and self.body.source_equals(other.body)
+            and self.binding.source_equals(other.binding)
+        )
 
 
 @dataclass(eq=True, unsafe_hash=True)
@@ -907,10 +1001,24 @@ class Assert(Object):
     value: Object
     cond: Object
 
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, Assert)
+            and self == other
+            and self.source_extent == other.source_extent
+            and self.value.source_equals(other.value)
+            and self.cond.source_equals(other.cond)
+        )
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class EnvObject(Object):
     env: Env
+
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return isinstance(other, EnvObject) and self == other and self.source_extent == other.source_extent
 
     def __str__(self) -> str:
         return f"EnvObject(keys={self.env.keys()})"
@@ -921,20 +1029,48 @@ class MatchCase(Object):
     pattern: Object
     body: Object
 
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, MatchCase)
+            and self == other
+            and self.source_extent == other.source_extent
+            and self.pattern.source_equals(other.pattern)
+            and self.body.source_equals(other.body)
+        )
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class MatchFunction(Object):
     cases: typing.List[MatchCase]
+
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, MatchFunction)
+            and self == other
+            and self.source_extent == other.source_extent
+            and all(
+                match_case.source_equals(other_match_case)
+                for match_case, other_match_case in zip(self.cases, other.cases)
+            )
+        )
 
 
 @dataclass(eq=True, unsafe_hash=True)
 class Relocation(Object):
     name: str
 
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return isinstance(other, Relocation) and self == other and self.source_extent == other.source_extent
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class NativeFunctionRelocation(Relocation):
-    pass
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return isinstance(other, NativeFunctionRelocation) and self.source_extent == other.source_extent
 
 
 @dataclass(eq=True, unsafe_hash=True)
@@ -942,16 +1078,40 @@ class NativeFunction(Object):
     name: str
     func: Callable[[Object], Object]
 
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return isinstance(other, NativeFunction) and self == other and self.source_extent == other.source_extent
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class Closure(Object):
     env: Env
     func: Union[Function, MatchFunction]
 
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, Closure)
+            and self == other
+            and self.source_extent == other.source_extent
+            and self.func.source_equals(other.func)
+        )
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class Record(Object):
     data: Dict[str, Object]
+
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, Record)
+            and self == other
+            and self.source_extent == other.source_extent
+            and all(
+                self.data[k1].source_equals(other.data[k2]) for k1, k2 in zip(sorted(self.data), sorted(other.data))
+            )
+        )
 
 
 @dataclass(eq=True, unsafe_hash=True)
@@ -959,11 +1119,30 @@ class Access(Object):
     obj: Object
     at: Object
 
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, Access)
+            and self == other
+            and self.source_extent == other.source_extent
+            and self.obj.source_equals(other.obj)
+            and self.at.source_equals(other.at)
+        )
+
 
 @dataclass(eq=True, unsafe_hash=True)
 class Variant(Object):
     tag: str
     value: Object
+
+    @override
+    def source_equals(self, other: Object) -> bool:
+        return (
+            isinstance(other, Variant)
+            and self == other
+            and self.source_extent == other.source_extent
+            and self.value.source_equals(other.value)
+        )
 
 
 tags = [

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -596,7 +596,7 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
             l = make_source_annotated_object(Hole, left_paren_source_extent.coalesce(next(tokens).source_extent))
         else:
             l = parse(tokens)
-            next(tokens)
+            object.__setattr__(l, "source_extent", left_paren_source_extent.coalesce(next(tokens).source_extent))
         return l
     elif isinstance(token, LeftBracket):
         list_start_source_extent = token.source_extent

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -1,6 +1,5 @@
 #!/usr/bin/env python3.10
 from __future__ import annotations
-import abc
 import argparse
 import base64
 import code
@@ -504,7 +503,6 @@ def make_source_annotated_object(cls: type, source_extent: Optional[SourceExtent
 def parse_unary(tokens: Peekable, p: float) -> "Object":
     token = next(tokens)
     l: Object
-    new_r: Object
     if isinstance(token, IntLit):
         return make_source_annotated_object(Int, token.source_extent, token.value)
     elif isinstance(token, FloatLit):

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -586,7 +586,7 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
         return make_source_annotated_object(
             MatchFunction,
             reduce(
-                lambda source_extent_one, source_extent_two: join_source_extents(source_extent_one, source_extent_two),
+                join_source_extents,
                 cases_source_extents,
             ),
             cases,

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -51,6 +51,12 @@ class SourceExtent:
         return SourceExtent(min(self.start, other.start), max(self.end, other.end)) if other else None
 
 
+def join_source_extents(
+    source_extent_one: Optional[SourceExtent], source_extent_two: Optional[SourceExtent]
+) -> Optional[SourceExtent]:
+    return source_extent_one.coalesce(source_extent_two) if source_extent_one else None
+
+
 @dataclass(eq=True)
 class Token:
     source_extent: SourceExtent = dataclasses.field(default_factory=SourceExtent, init=False, compare=False)

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -495,6 +495,12 @@ def gensym_reset() -> None:
 gensym_reset()
 
 
+def make_source_annotated_object(cls: type, source_extent: Optional[SourceExtent], *args: Any) -> Object:
+    result: Object = cls(*args)
+    result.source_extent = source_extent
+    return result
+
+
 def parse_unary(tokens: Peekable, p: float) -> "Object":
     token = next(tokens)
     l: Object

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -644,16 +644,13 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
         if isinstance(r, Float):
             assert r.value >= 0, "Tokens should never have negative values"
             return make_source_annotated_object(Float, source_extent, -r.value)
-        binop = Binop(BinopKind.SUB, Int(0), r)
-        binop.source_extent = source_extent
-        return binop
+        return make_source_annotated_object(Binop, source_extent, BinopKind.SUB, Int(0), r)
     else:
         raise UnexpectedTokenError(token)
 
 
 def parse_binary(tokens: Peekable, p: float) -> "Object":
     l: Object = parse_unary(tokens, p)
-    new_l: Object
     while True:
         op: Token
         try:
@@ -668,9 +665,9 @@ def parse_binary(tokens: Peekable, p: float) -> "Object":
             if pl < p:
                 break
             arg = parse_binary(tokens, pr)
-            new_l = Apply(l, arg)
-            new_l.source_extent = l.source_extent.coalesce(arg.source_extent) if l.source_extent else None
-            l = new_l
+            l = make_source_annotated_object(
+                Apply, l.source_extent.coalesce(arg.source_extent) if l.source_extent else None, l, arg
+            )
             continue
         prec = PS[op.value]
         pl, pr = prec.pl, prec.pr

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1207,7 +1207,7 @@ class ParserTests(unittest.TestCase):
         )
         int_lit.source_extent = source_extent
         int_ast = make_source_annotated_object(Int, source_extent, 1)
-        self.assertTrue(parse(Peekable(iter([int_lit]))).source_equals(int_ast))
+        self.assertTrue(parse(Peekable(iter([int_lit]))).source_extent == int_ast.source_extent)
 
     def test_parse_float_preserves_source_extent(self) -> None:
         float_lit = FloatLit(3.2)
@@ -1216,7 +1216,7 @@ class ParserTests(unittest.TestCase):
         )
         float_lit.source_extent = source_extent
         float_ast = make_source_annotated_object(Float, source_extent, 3.2)
-        self.assertTrue(parse(Peekable(iter([float_lit]))).source_equals(float_ast))
+        self.assertTrue(parse(Peekable(iter([float_lit]))).source_extent == float_ast.source_extent)
 
     def test_parse_string_preserves_source_extent(self) -> None:
         string_lit = StringLit("Hello")
@@ -1225,7 +1225,7 @@ class ParserTests(unittest.TestCase):
         )
         string_lit.source_extent = source_extent
         string_ast = make_source_annotated_object(String, source_extent, "Hello")
-        self.assertTrue(parse(Peekable(iter([string_lit]))).source_equals(string_ast))
+        self.assertTrue(parse(Peekable(iter([string_lit]))).source_extent == string_ast.source_extent)
 
     def test_parse_bytes_preserves_source_extent(self) -> None:
         bytes_lit = BytesLit("QUJD", 64)
@@ -1234,7 +1234,7 @@ class ParserTests(unittest.TestCase):
         )
         bytes_lit.source_extent = source_extent
         bytes_ast = make_source_annotated_object(Bytes, source_extent, base64.b64decode("QUJD"))
-        self.assertTrue(parse(Peekable(iter([bytes_lit]))).source_equals(bytes_ast))
+        self.assertTrue(parse(Peekable(iter([bytes_lit]))).source_extent == bytes_ast.source_extent)
 
     def test_parse_var_preserves_source_extent(self) -> None:
         var = Name("x")
@@ -1243,7 +1243,7 @@ class ParserTests(unittest.TestCase):
         )
         var.source_extent = source_extent
         var_ast = make_source_annotated_object(Var, source_extent, "x")
-        self.assertTrue(parse(Peekable(iter([var]))).source_equals(var_ast))
+        self.assertTrue(parse(Peekable(iter([var]))).source_extent == var_ast.source_extent)
 
     def test_parse_hole_preserves_source_extent(self) -> None:
         left_paren = LeftParen()
@@ -1260,7 +1260,7 @@ class ParserTests(unittest.TestCase):
                 start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=2, byteno=1)
             ),
         )
-        self.assertTrue(parse(Peekable(iter([left_paren, right_paren]))).source_equals(hole))
+        self.assertTrue(parse(Peekable(iter([left_paren, right_paren]))).source_extent == hole.source_extent)
 
     def test_parse_spread_preserves_source_extent(self) -> None:
         ellipsis = Operator("...")
@@ -1278,7 +1278,7 @@ class ParserTests(unittest.TestCase):
             ),
             "x",
         )
-        self.assertTrue(parse(Peekable(iter([ellipsis, name]))).source_equals(spread))
+        self.assertTrue(parse(Peekable(iter([ellipsis, name]))).source_extent == spread.source_extent)
 
     def test_parse_binop_preserves_source_extent(self) -> None:
         first_addend = IntLit(1)
@@ -1305,7 +1305,9 @@ class ParserTests(unittest.TestCase):
             first_addend_ast,
             second_addend_ast,
         )
-        self.assertTrue(parse(Peekable(iter([first_addend, operator, second_addend]))).source_equals(binop))
+        self.assertTrue(
+            parse(Peekable(iter([first_addend, operator, second_addend]))).source_extent == binop.source_extent
+        )
 
     def test_parse_list_preserves_source_extent(self) -> None:
         left_bracket = LeftBracket()
@@ -1337,7 +1339,10 @@ class ParserTests(unittest.TestCase):
             ),
             [one_ast, two_ast],
         )
-        self.assertTrue(parse(Peekable(iter([left_bracket, one, comma, two, right_bracket]))).source_equals(list_ast))
+        self.assertTrue(
+            parse(Peekable(iter([left_bracket, one, comma, two, right_bracket]))).source_extent
+            == list_ast.source_extent
+        )
 
 
 class MatchTests(unittest.TestCase):

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1268,6 +1268,9 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
         num = IntLit(1)
+        num.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
+        )
         right_paren = RightParen()
         right_paren.source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -2576,23 +2576,35 @@ class EndToEndTests(EndToEndTestsBase):
         """
         )
 
-        outer_function = env_object.env["count_bits"].func
+        assert isinstance(env_object, EnvObject)
+
+        count_bits_closure = env_object.env["count_bits"]
+
+        assert isinstance(count_bits_closure, Closure)
+
+        outer_function = count_bits_closure.func
         outer_function_source_extent = SourceExtent(
             start=SourceLocation(lineno=2, colno=22, byteno=22),
             end=SourceLocation(lineno=5, colno=24, byteno=241),
         )
 
-        match_function_one = outer_function.body.cases[0]
+        assert isinstance(outer_function, Function)
+
+        inner_function = outer_function.body
+
+        assert isinstance(inner_function, MatchFunction)
+
+        match_function_one = inner_function.cases[0]
         match_function_one_source_extent = SourceExtent(
             start=SourceLocation(lineno=3, colno=11, byteno=42), end=SourceLocation(lineno=3, colno=92, byteno=123)
         )
 
-        match_function_two = outer_function.body.cases[1]
+        match_function_two = inner_function.cases[1]
         match_function_two_source_extent = SourceExtent(
             start=SourceLocation(lineno=4, colno=11, byteno=135), end=SourceLocation(lineno=4, colno=92, byteno=216)
         )
 
-        match_function_three = outer_function.body.cases[2]
+        match_function_three = inner_function.cases[2]
         match_function_three_source_extent = SourceExtent(
             start=SourceLocation(lineno=5, colno=11, byteno=228), end=SourceLocation(lineno=5, colno=24, byteno=241)
         )
@@ -2622,13 +2634,29 @@ class EndToEndTests(EndToEndTestsBase):
         """
         )
 
-        outer_function = env_object.env["collatz"].func
+        assert isinstance(env_object, EnvObject)
+
+        collatz_closure = env_object.env["collatz"]
+
+        assert isinstance(collatz_closure, Closure)
+
+        outer_function = collatz_closure.func
+
+        assert isinstance(outer_function, Function)
+
         outer_function_source_extent = SourceExtent(
             start=SourceLocation(lineno=2, colno=19, byteno=19),
             end=SourceLocation(lineno=5, colno=79, byteno=205),
         )
 
-        apply_ast = outer_function.body.cases[1].body
+        inner_function = outer_function.body
+
+        assert isinstance(inner_function, MatchFunction)
+
+        apply_ast = inner_function.cases[1].body
+
+        assert isinstance(apply_ast, Apply)
+
         arg = apply_ast.arg
         func = apply_ast.func
 

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1271,9 +1271,9 @@ class ParserTests(unittest.TestCase):
         num_ast = make_source_annotated_object(
             Int,
             SourceExtent(
-              start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
+                start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
             ),
-            1
+            1,
         )
         right_paren = RightParen()
         right_paren.source_extent = SourceExtent(
@@ -1284,10 +1284,12 @@ class ParserTests(unittest.TestCase):
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
             ),
-            1
+            1,
         )
-        self.assertTrue(parse(Peekable(iter([left_paren, num, right_paren]))).source_extent == parenthesized_num.source_extent)
-        
+        self.assertTrue(
+            parse(Peekable(iter([left_paren, num, right_paren]))).source_extent == parenthesized_num.source_extent
+        )
+
     def test_parse_spread_preserves_source_extent(self) -> None:
         ellipsis = Operator("...")
         ellipsis.source_extent = SourceExtent(
@@ -2638,34 +2640,17 @@ class EndToEndTests(EndToEndTestsBase):
         func = apply_ast.func
 
         arg_source_extent = SourceExtent(
-            start=SourceLocation(
-                lineno=4,
-                colno=18,
-                byteno=68
-            ),
-            end=SourceLocation(
-                lineno=4,
-                colno=29,
-                byteno=79
-            )
+            start=SourceLocation(lineno=4, colno=18, byteno=68), end=SourceLocation(lineno=4, colno=29, byteno=79)
         )
 
         func_source_extent = SourceExtent(
-            start=SourceLocation(
-                lineno=4,
-                colno=34,
-                byteno=84
-            ),
-            end=SourceLocation(
-                lineno=5,
-                colno=79,
-                byteno=205
-            )
+            start=SourceLocation(lineno=4, colno=34, byteno=84), end=SourceLocation(lineno=5, colno=79, byteno=205)
         )
 
         self.assertTrue(outer_function.source_extent == outer_function_source_extent)
         self.assertTrue(arg.source_extent == arg_source_extent)
         self.assertTrue(func.source_extent == func_source_extent)
+
 
 class ClosureOptimizeTests(unittest.TestCase):
     def test_int(self) -> None:

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1254,9 +1254,11 @@ class ParserTests(unittest.TestCase):
         right_paren.source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
         )
-        hole = Hole()
-        hole.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=2, byteno=1)
+        hole = make_source_annotated_object(
+            Hole,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=2, byteno=1)
+            ),
         )
         self.assertTrue(parse(Peekable(iter([left_paren, right_paren]))).source_equals(hole))
 
@@ -1269,9 +1271,12 @@ class ParserTests(unittest.TestCase):
         name.source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=4, byteno=3), end=SourceLocation(lineno=1, colno=4, byteno=3)
         )
-        spread = Spread("x")
-        spread.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=4, byteno=3)
+        spread = make_source_annotated_object(
+            Spread,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=4, byteno=3)
+            ),
+            "x",
         )
         self.assertTrue(parse(Peekable(iter([ellipsis, name]))).source_equals(spread))
 

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1,3 +1,4 @@
+import base64
 import unittest
 import re
 from typing import Optional
@@ -1198,6 +1199,141 @@ class ParserTests(unittest.TestCase):
     def test_apply_with_variant_args(self) -> None:
         ast = parse(tokenize("f #true() #false()"))
         self.assertEqual(ast, Apply(Apply(Var("f"), TRUE), FALSE))
+
+    def test_parse_int_preserves_source_extent(self) -> None:
+        int_lit = IntLit(1)
+        source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+        )
+        int_lit.source_extent = source_extent
+        int_ast = Int(1)
+        int_ast.source_extent = source_extent
+        self.assertTrue(parse(Peekable(iter([int_lit]))).source_equals(int_ast))
+
+    def test_parse_float_preserves_source_extent(self) -> None:
+        float_lit = FloatLit(3.2)
+        source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
+        )
+        float_lit.source_extent = source_extent
+        float_ast = Float(3.2)
+        float_ast.source_extent = source_extent
+        self.assertTrue(parse(Peekable(iter([float_lit]))).source_equals(float_ast))
+
+    def test_parse_string_preserves_source_extent(self) -> None:
+        string_lit = StringLit("Hello")
+        source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=7, byteno=6)
+        )
+        string_lit.source_extent = source_extent
+        string_ast = String("Hello")
+        string_ast.source_extent = source_extent
+        self.assertTrue(parse(Peekable(iter([string_lit]))).source_equals(string_ast))
+
+    def test_parse_bytes_preserves_source_extent(self) -> None:
+        bytes_lit = BytesLit("QUJD", 64)
+        source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=9, byteno=8)
+        )
+        bytes_lit.source_extent = source_extent
+        bytes_ast = Bytes(base64.b64decode("QUJD"))
+        bytes_ast.source_extent = source_extent
+        self.assertTrue(parse(Peekable(iter([bytes_lit]))).source_equals(bytes_ast))
+
+    def test_parse_var_preserves_source_extent(self) -> None:
+        var = Name("x")
+        source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+        )
+        var.source_extent = source_extent
+        var_ast = Var("x")
+        var_ast.source_extent = source_extent
+        self.assertTrue(parse(Peekable(iter([var]))).source_equals(var_ast))
+
+    def test_parse_hole_preserves_source_extent(self) -> None:
+        left_paren = LeftParen()
+        left_paren.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+        )
+        right_paren = RightParen()
+        right_paren.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
+        )
+        hole = Hole()
+        hole.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=2, byteno=1)
+        )
+        self.assertTrue(parse(Peekable(iter([left_paren, right_paren]))).source_equals(hole))
+
+    def test_parse_spread_preserves_source_extent(self) -> None:
+        ellipsis = Operator("...")
+        ellipsis.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
+        )
+        name = Name("x")
+        name.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=4, byteno=3), end=SourceLocation(lineno=1, colno=4, byteno=3)
+        )
+        spread = Spread("x")
+        spread.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=4, byteno=3)
+        )
+        self.assertTrue(parse(Peekable(iter([ellipsis, name]))).source_equals(spread))
+
+    def test_parse_binop_preserves_source_extent(self) -> None:
+        first_addend = IntLit(1)
+        first_addend.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+        )
+        operator = Operator("+")
+        operator.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
+        )
+        second_addend = IntLit(2)
+        second_addend.source_extent = SourceExtent(
+            start=SourceLocation(lineno=2, colno=5, byteno=4), end=SourceLocation(lineno=2, colno=5, byteno=4)
+        )
+        first_addend_ast = Int(1)
+        first_addend_ast.source_extent = first_addend.source_extent
+        operator_ast = BinopKind.ADD
+        second_addend_ast = Int(2)
+        second_addend_ast.source_extent = second_addend.source_extent
+        binop = Binop(operator_ast, first_addend_ast, second_addend_ast)
+        binop.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=2, colno=5, byteno=4)
+        )
+        self.assertTrue(parse(Peekable(iter([first_addend, operator, second_addend]))).source_equals(binop))
+
+    def test_parse_list_preserves_source_extent(self) -> None:
+        left_bracket = LeftBracket()
+        left_bracket.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+        )
+        one = IntLit(1)
+        one.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
+        )
+        comma = Operator(",")
+        comma.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
+        )
+        two = IntLit(2)
+        two.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=5, byteno=4), end=SourceLocation(lineno=1, colno=5, byteno=4)
+        )
+        right_bracket = RightBracket()
+        right_bracket.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=6, byteno=5), end=SourceLocation(lineno=1, colno=6, byteno=5)
+        )
+        one_ast = Int(1)
+        one_ast.source_extent = one.source_extent
+        two_ast = Int(2)
+        two_ast.source_extent = two.source_extent
+        list_ast = List([one_ast, two_ast])
+        list_ast.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=6, byteno=5)
+        )
+        self.assertTrue(parse(Peekable(iter([left_bracket, one, comma, two, right_bracket]))).source_equals(list_ast))
 
 
 class MatchTests(unittest.TestCase):

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -2619,7 +2619,7 @@ class EndToEndTests(EndToEndTestsBase):
             )
         )
 
-    def test_eval_count_bits_function_preserves_source_extents(self) -> None:
+    def test_eval_collatz_function_preserves_source_extents(self) -> None:
         env_object = self._run(
             """
         collatz = count ->

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1267,15 +1267,15 @@ class ParserTests(unittest.TestCase):
         left_paren.source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
-        num = IntLit(1)
-        num.source_extent = SourceExtent(
+        int_lit = IntLit(1)
+        int_lit.source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
         )
         right_paren = RightParen()
         right_paren.source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
         )
-        parenthesized_num = make_source_annotated_object(
+        parenthesized_int_lit = make_source_annotated_object(
             Int,
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
@@ -1283,7 +1283,8 @@ class ParserTests(unittest.TestCase):
             1,
         )
         self.assertTrue(
-            parse(Peekable(iter([left_paren, num, right_paren]))).source_extent == parenthesized_num.source_extent
+            parse(Peekable(iter([left_paren, int_lit, right_paren]))).source_extent
+            == parenthesized_int_lit.source_extent
         )
 
     def test_parse_spread_preserves_source_extent(self) -> None:

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1262,6 +1262,32 @@ class ParserTests(unittest.TestCase):
         )
         self.assertTrue(parse(Peekable(iter([left_paren, right_paren]))).source_extent == hole.source_extent)
 
+    def test_parenthesized_expression_preserves_source_extent(self) -> None:
+        left_paren = LeftParen()
+        left_paren.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+        )
+        num = IntLit(1)
+        num_ast = make_source_annotated_object(
+            Int,
+            SourceExtent(
+              start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
+            ),
+            1
+        )
+        right_paren = RightParen()
+        right_paren.source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
+        )
+        parenthesized_num = make_source_annotated_object(
+            Int,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
+            ),
+            1
+        )
+        self.assertTrue(parse(Peekable(iter([left_paren, num, right_paren]))).source_extent == parenthesized_num.source_extent)
+        
     def test_parse_spread_preserves_source_extent(self) -> None:
         ellipsis = Operator("...")
         ellipsis.source_extent = SourceExtent(

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1268,13 +1268,6 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
         num = IntLit(1)
-        num_ast = make_source_annotated_object(
-            Int,
-            SourceExtent(
-                start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
-            ),
-            1,
-        )
         right_paren = RightParen()
         right_paren.source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1206,8 +1206,7 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
         int_lit.source_extent = source_extent
-        int_ast = Int(1)
-        int_ast.source_extent = source_extent
+        int_ast = make_source_annotated_object(Int, source_extent, 1)
         self.assertTrue(parse(Peekable(iter([int_lit]))).source_equals(int_ast))
 
     def test_parse_float_preserves_source_extent(self) -> None:
@@ -1216,8 +1215,7 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
         )
         float_lit.source_extent = source_extent
-        float_ast = Float(3.2)
-        float_ast.source_extent = source_extent
+        float_ast = make_source_annotated_object(Float, source_extent, 3.2)
         self.assertTrue(parse(Peekable(iter([float_lit]))).source_equals(float_ast))
 
     def test_parse_string_preserves_source_extent(self) -> None:
@@ -1226,8 +1224,7 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=7, byteno=6)
         )
         string_lit.source_extent = source_extent
-        string_ast = String("Hello")
-        string_ast.source_extent = source_extent
+        string_ast = make_source_annotated_object(String, source_extent, "Hello")
         self.assertTrue(parse(Peekable(iter([string_lit]))).source_equals(string_ast))
 
     def test_parse_bytes_preserves_source_extent(self) -> None:
@@ -1236,8 +1233,7 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=9, byteno=8)
         )
         bytes_lit.source_extent = source_extent
-        bytes_ast = Bytes(base64.b64decode("QUJD"))
-        bytes_ast.source_extent = source_extent
+        bytes_ast = make_source_annotated_object(Bytes, source_extent, base64.b64decode("QUJD"))
         self.assertTrue(parse(Peekable(iter([bytes_lit]))).source_equals(bytes_ast))
 
     def test_parse_var_preserves_source_extent(self) -> None:
@@ -1246,8 +1242,7 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
         var.source_extent = source_extent
-        var_ast = Var("x")
-        var_ast.source_extent = source_extent
+        var_ast = make_source_annotated_object(Var, source_extent, "x")
         self.assertTrue(parse(Peekable(iter([var]))).source_equals(var_ast))
 
     def test_parse_hole_preserves_source_extent(self) -> None:
@@ -1293,14 +1288,17 @@ class ParserTests(unittest.TestCase):
         second_addend.source_extent = SourceExtent(
             start=SourceLocation(lineno=2, colno=5, byteno=4), end=SourceLocation(lineno=2, colno=5, byteno=4)
         )
-        first_addend_ast = Int(1)
-        first_addend_ast.source_extent = first_addend.source_extent
+        first_addend_ast = make_source_annotated_object(Int, first_addend.source_extent, 1)
         operator_ast = BinopKind.ADD
-        second_addend_ast = Int(2)
-        second_addend_ast.source_extent = second_addend.source_extent
-        binop = Binop(operator_ast, first_addend_ast, second_addend_ast)
-        binop.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=2, colno=5, byteno=4)
+        second_addend_ast = make_source_annotated_object(Int, second_addend.source_extent, 2)
+        binop = make_source_annotated_object(
+            Binop,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=2, colno=5, byteno=4)
+            ),
+            operator_ast,
+            first_addend_ast,
+            second_addend_ast,
         )
         self.assertTrue(parse(Peekable(iter([first_addend, operator, second_addend]))).source_equals(binop))
 
@@ -1325,13 +1323,14 @@ class ParserTests(unittest.TestCase):
         right_bracket.source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=6, byteno=5), end=SourceLocation(lineno=1, colno=6, byteno=5)
         )
-        one_ast = Int(1)
-        one_ast.source_extent = one.source_extent
-        two_ast = Int(2)
-        two_ast.source_extent = two.source_extent
-        list_ast = List([one_ast, two_ast])
-        list_ast.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=6, byteno=5)
+        one_ast = make_source_annotated_object(Int, one.source_extent, 1)
+        two_ast = make_source_annotated_object(Int, two.source_extent, 2)
+        list_ast = make_source_annotated_object(
+            List,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=6, byteno=5)
+            ),
+            [one_ast, two_ast],
         )
         self.assertTrue(parse(Peekable(iter([left_bracket, one, comma, two, right_bracket]))).source_equals(list_ast))
 

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -2571,6 +2571,101 @@ class EndToEndTests(EndToEndTestsBase):
         with self.assertRaisesRegex(InferenceError, "int and float"):
             self._run("1 / 2 + 3", check=True)
 
+    def test_eval_count_bits_function_preserves_source_extents(self) -> None:
+        env_object = self._run(
+            """
+        count_bits = counts ->
+          | [1, ...bits] -> count_bits { zeros = counts@zeros, ones = 1 + counts@ones } bits
+          | [0, ...bits] -> count_bits { zeros = 1 + counts@zeros, ones = counts@ones } bits
+          | [] -> counts
+        """
+        )
+
+        outer_function = env_object.env["count_bits"].func
+        outer_function_source_extent = SourceExtent(
+            start=SourceLocation(lineno=2, colno=22, byteno=22),
+            end=SourceLocation(lineno=5, colno=24, byteno=241),
+        )
+
+        match_function_one = outer_function.body.cases[0]
+        match_function_one_source_extent = SourceExtent(
+            start=SourceLocation(lineno=3, colno=11, byteno=42), end=SourceLocation(lineno=3, colno=92, byteno=123)
+        )
+
+        match_function_two = outer_function.body.cases[1]
+        match_function_two_source_extent = SourceExtent(
+            start=SourceLocation(lineno=4, colno=11, byteno=135), end=SourceLocation(lineno=4, colno=92, byteno=216)
+        )
+
+        match_function_three = outer_function.body.cases[2]
+        match_function_three_source_extent = SourceExtent(
+            start=SourceLocation(lineno=5, colno=11, byteno=228), end=SourceLocation(lineno=5, colno=24, byteno=241)
+        )
+
+        match_functions = [match_function_one, match_function_two, match_function_three]
+        match_function_source_extents = [
+            match_function_one_source_extent,
+            match_function_two_source_extent,
+            match_function_three_source_extent,
+        ]
+
+        self.assertTrue(outer_function.source_extent == outer_function_source_extent)
+        self.assertTrue(
+            all(
+                match_function.source_extent == source_extent
+                for match_function, source_extent in zip(match_functions, match_function_source_extents)
+            )
+        )
+
+    def test_eval_count_bits_function_preserves_source_extents(self) -> None:
+        env_object = self._run(
+            """
+        collatz = count ->
+          | 1 -> count
+          | n -> (n % 2 == 0) |> | #true () -> collatz (count + 1) (n // 2)
+                                 | #false () -> collatz (count + 1) (3 * n + 1)
+        """
+        )
+
+        outer_function = env_object.env["collatz"].func
+        outer_function_source_extent = SourceExtent(
+            start=SourceLocation(lineno=2, colno=19, byteno=19),
+            end=SourceLocation(lineno=5, colno=79, byteno=205),
+        )
+
+        apply_ast = outer_function.body.cases[1].body
+        arg = apply_ast.arg
+        func = apply_ast.func
+
+        arg_source_extent = SourceExtent(
+            start=SourceLocation(
+                lineno=4,
+                colno=18,
+                byteno=68
+            ),
+            end=SourceLocation(
+                lineno=4,
+                colno=29,
+                byteno=79
+            )
+        )
+
+        func_source_extent = SourceExtent(
+            start=SourceLocation(
+                lineno=4,
+                colno=34,
+                byteno=84
+            ),
+            end=SourceLocation(
+                lineno=5,
+                colno=79,
+                byteno=205
+            )
+        )
+
+        self.assertTrue(outer_function.source_extent == outer_function_source_extent)
+        self.assertTrue(arg.source_extent == arg_source_extent)
+        self.assertTrue(func.source_extent == func_source_extent)
 
 class ClosureOptimizeTests(unittest.TestCase):
     def test_int(self) -> None:


### PR DESCRIPTION
I have implemented the functionality necessary to preserve source information through the parsing stage, but I have not added any tests yet. I was looking to see if you had any guidance about the number and kind of tests we would like to see. I was thinking of modifying the parser tests so that the provided streams of tokens used for input would also have artificially annotated `source_extent` values, but I understand that may blow up the size of the source code of the tests if we were to check for equality on source location values for all such parser tests. I would be truly grateful for your input.