### PR TITLE
Address feedback from PR #241

### DIFF
--- a/scrapscript.py
+++ b/scrapscript.py
@@ -212,19 +212,7 @@ class Lexer:
         return self.text[self.idx]
 
     def make_token(self, cls: type, *args: Any) -> Token:
-        result: Token = cls(*args)
-
-        # Set start of token's source extent
-        result.source_extent.start.lineno = self.current_token_source_extent.start.lineno
-        result.source_extent.start.colno = self.current_token_source_extent.start.colno
-        result.source_extent.start.byteno = self.current_token_source_extent.start.byteno
-
-        # Set end of token's source extent
-        result.source_extent.end.colno = self.current_token_source_extent.end.colno
-        result.source_extent.end.lineno = self.current_token_source_extent.end.lineno
-        result.source_extent.end.byteno = self.current_token_source_extent.end.byteno
-
-        return result
+        return make_source_annotated_token(cls, copy.deepcopy(self.current_token_source_extent), *args)
 
     def read_tokens(self) -> Generator[Token, None, None]:
         while (token := self.read_token()) and not isinstance(token, EOF):

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -15,7 +15,6 @@ import typing
 import urllib.request
 from dataclasses import dataclass
 from enum import auto
-from functools import reduce
 from types import ModuleType
 from typing import Any, Callable, Dict, Generator, Iterator, Mapping, Optional, Set, Tuple, Union
 
@@ -568,6 +567,7 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
             MatchCase, pipe_source_extent.coalesce(expr.source_extent), expr.arg, expr.body
         )
         cases = [match_case]
+        match_function_source_extent = match_case.source_extent
         while True:
             try:
                 if tokens.peek() != Operator("|"):
@@ -582,13 +582,10 @@ def parse_unary(tokens: Peekable, p: float) -> "Object":
                 MatchCase, pipe_source_extent.coalesce(expr.source_extent), expr.arg, expr.body
             )
             cases.append(match_case)
-        cases_source_extents = [case_branch.source_extent for case_branch in cases]
+            match_function_source_extent = join_source_extents(match_function_source_extent, match_case.source_extent)
         return make_source_annotated_object(
             MatchFunction,
-            reduce(
-                join_source_extents,
-                cases_source_extents,
-            ),
+            match_function_source_extent,
             cases,
         )
     elif isinstance(token, LeftParen):

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -216,7 +216,8 @@ class Lexer:
         return self.text[self.idx]
 
     def make_token(self, cls: type, *args: Any) -> Token:
-        return make_source_annotated_token(cls, copy.deepcopy(self.current_token_source_extent), *args)
+        result: Token = cls(*args)
+        return result.with_source(copy.deepcopy(self.current_token_source_extent))
 
     def read_tokens(self) -> Generator[Token, None, None]:
         while (token := self.read_token()) and not isinstance(token, EOF):

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import argparse
 import base64
 import code
+import copy
 import dataclasses
 import enum
 import functools
@@ -349,6 +350,12 @@ class Lexer:
             buf += self.read_char()
         base, _, value = buf.rpartition("'")
         return self.make_token(BytesLit, value, int(base) if base else 64)
+
+
+def make_source_annotated_token(cls: type, source_extent: SourceExtent, *args: Any) -> Token:
+    result: Token = cls(*args)
+    result.source_extent = source_extent
+    return result
 
 
 PEEK_EMPTY = object()

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -59,6 +59,10 @@ def join_source_extents(
 class Token:
     source_extent: SourceExtent = dataclasses.field(default_factory=SourceExtent, init=False, compare=False)
 
+    def with_source(self, source_extent: SourceExtent) -> Token:
+        self.source_extent = source_extent
+        return self
+
 
 @dataclass(eq=True)
 class IntLit(Token):

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -345,12 +345,6 @@ class Lexer:
         return self.make_token(BytesLit, value, int(base) if base else 64)
 
 
-def make_source_annotated_token(cls: type, source_extent: SourceExtent, *args: Any) -> Token:
-    result: Token = cls(*args)
-    result.source_extent = source_extent
-    return result
-
-
 PEEK_EMPTY = object()
 
 

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1203,49 +1203,47 @@ class ParserTests(unittest.TestCase):
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
-        int_lit = make_source_annotated_token(IntLit, source_extent, 1)
+        int_lit = IntLit(1).with_source(source_extent)
         self.assertEqual(parse(Peekable(iter([int_lit]))).source_extent, source_extent)
 
     def test_parse_float_preserves_source_extent(self) -> None:
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
         )
-        float_lit = make_source_annotated_token(FloatLit, source_extent, 3.2)
+        float_lit = FloatLit(3.2).with_source(source_extent)
         self.assertEqual(parse(Peekable(iter([float_lit]))).source_extent, source_extent)
 
     def test_parse_string_preserves_source_extent(self) -> None:
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=7, byteno=6)
         )
-        string_lit = make_source_annotated_token(StringLit, source_extent, "Hello")
+        string_lit = StringLit("Hello").with_source(source_extent)
         self.assertEqual(parse(Peekable(iter([string_lit]))).source_extent, source_extent)
 
     def test_parse_bytes_preserves_source_extent(self) -> None:
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=9, byteno=8)
         )
-        bytes_lit = make_source_annotated_token(BytesLit, source_extent, "QUJD", 64)
+        bytes_lit = BytesLit("QUJD", 64).with_source(source_extent)
         self.assertEqual(parse(Peekable(iter([bytes_lit]))).source_extent, source_extent)
 
     def test_parse_var_preserves_source_extent(self) -> None:
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
-        var = make_source_annotated_token(Name, source_extent, "x")
+        var = Name("x").with_source(source_extent)
         self.assertEqual(parse(Peekable(iter([var]))).source_extent, source_extent)
 
     def test_parse_hole_preserves_source_extent(self) -> None:
-        left_paren = make_source_annotated_token(
-            LeftParen,
+        left_paren = LeftParen().with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
-            ),
+            )
         )
-        right_paren = make_source_annotated_token(
-            RightParen,
+        right_paren = RightParen().with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
-            ),
+            )
         )
         hole_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=2, byteno=1)
@@ -1253,24 +1251,20 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(parse(Peekable(iter([left_paren, right_paren]))).source_extent, hole_source_extent)
 
     def test_parenthesized_expression_preserves_source_extent(self) -> None:
-        left_paren = make_source_annotated_token(
-            LeftParen,
+        left_paren = LeftParen().with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
-            ),
+            )
         )
-        int_lit = make_source_annotated_token(
-            IntLit,
+        int_lit = IntLit(1).with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
-            ),
-            1,
+            )
         )
-        right_paren = make_source_annotated_token(
-            RightParen,
+        right_paren = RightParen().with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
-            ),
+            )
         )
         parenthesized_int_lit_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
@@ -1280,19 +1274,15 @@ class ParserTests(unittest.TestCase):
         )
 
     def test_parse_spread_preserves_source_extent(self) -> None:
-        ellipsis = make_source_annotated_token(
-            Operator,
+        ellipsis = Operator("...").with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
-            ),
-            "...",
+            )
         )
-        name = make_source_annotated_token(
-            Name,
+        name = Name("x").with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=4, byteno=3), end=SourceLocation(lineno=1, colno=4, byteno=3)
-            ),
-            "x",
+            )
         )
         spread_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=4, byteno=3)
@@ -1300,26 +1290,20 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(parse(Peekable(iter([ellipsis, name]))).source_extent, spread_source_extent)
 
     def test_parse_binop_preserves_source_extent(self) -> None:
-        first_addend = make_source_annotated_token(
-            IntLit,
+        first_addend = IntLit(1).with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
-            ),
-            1,
+            )
         )
-        operator = make_source_annotated_token(
-            Operator,
+        operator = Operator("+").with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
-            ),
-            "+",
+            )
         )
-        second_addend = make_source_annotated_token(
-            IntLit,
+        second_addend = IntLit(2).with_source(
             SourceExtent(
                 start=SourceLocation(lineno=2, colno=5, byteno=4), end=SourceLocation(lineno=2, colno=5, byteno=4)
-            ),
-            2,
+            )
         )
         binop_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=2, colno=5, byteno=4)
@@ -1329,38 +1313,30 @@ class ParserTests(unittest.TestCase):
         )
 
     def test_parse_list_preserves_source_extent(self) -> None:
-        left_bracket = make_source_annotated_token(
-            LeftBracket,
+        left_bracket = LeftBracket().with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
-            ),
+            )
         )
-        one = make_source_annotated_token(
-            IntLit,
+        one = IntLit(1).with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
-            ),
-            1,
+            )
         )
-        comma = make_source_annotated_token(
-            Operator,
+        comma = Operator(",").with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
-            ),
-            ",",
+            )
         )
-        two = make_source_annotated_token(
-            IntLit,
+        two = IntLit(2).with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=5, byteno=4), end=SourceLocation(lineno=1, colno=5, byteno=4)
-            ),
-            2,
+            )
         )
-        right_bracket = make_source_annotated_token(
-            RightBracket,
+        right_bracket = RightBracket().with_source(
             SourceExtent(
                 start=SourceLocation(lineno=1, colno=6, byteno=5), end=SourceLocation(lineno=1, colno=6, byteno=5)
-            ),
+            )
         )
         list_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=6, byteno=5)

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1,4 +1,3 @@
-import base64
 import unittest
 import re
 from typing import Optional
@@ -1206,8 +1205,7 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
         int_lit.source_extent = source_extent
-        int_ast = make_source_annotated_object(Int, source_extent, 1)
-        self.assertTrue(parse(Peekable(iter([int_lit]))).source_extent == int_ast.source_extent)
+        self.assertTrue(parse(Peekable(iter([int_lit]))).source_extent == source_extent)
 
     def test_parse_float_preserves_source_extent(self) -> None:
         float_lit = FloatLit(3.2)
@@ -1215,8 +1213,7 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
         )
         float_lit.source_extent = source_extent
-        float_ast = make_source_annotated_object(Float, source_extent, 3.2)
-        self.assertTrue(parse(Peekable(iter([float_lit]))).source_extent == float_ast.source_extent)
+        self.assertTrue(parse(Peekable(iter([float_lit]))).source_extent == source_extent)
 
     def test_parse_string_preserves_source_extent(self) -> None:
         string_lit = StringLit("Hello")
@@ -1224,8 +1221,7 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=7, byteno=6)
         )
         string_lit.source_extent = source_extent
-        string_ast = make_source_annotated_object(String, source_extent, "Hello")
-        self.assertTrue(parse(Peekable(iter([string_lit]))).source_extent == string_ast.source_extent)
+        self.assertTrue(parse(Peekable(iter([string_lit]))).source_extent == source_extent)
 
     def test_parse_bytes_preserves_source_extent(self) -> None:
         bytes_lit = BytesLit("QUJD", 64)
@@ -1233,8 +1229,7 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=9, byteno=8)
         )
         bytes_lit.source_extent = source_extent
-        bytes_ast = make_source_annotated_object(Bytes, source_extent, base64.b64decode("QUJD"))
-        self.assertTrue(parse(Peekable(iter([bytes_lit]))).source_extent == bytes_ast.source_extent)
+        self.assertTrue(parse(Peekable(iter([bytes_lit]))).source_extent == source_extent)
 
     def test_parse_var_preserves_source_extent(self) -> None:
         var = Name("x")
@@ -1242,8 +1237,7 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
         var.source_extent = source_extent
-        var_ast = make_source_annotated_object(Var, source_extent, "x")
-        self.assertTrue(parse(Peekable(iter([var]))).source_extent == var_ast.source_extent)
+        self.assertTrue(parse(Peekable(iter([var]))).source_extent == source_extent)
 
     def test_parse_hole_preserves_source_extent(self) -> None:
         left_paren = LeftParen()
@@ -1254,13 +1248,10 @@ class ParserTests(unittest.TestCase):
         right_paren.source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
         )
-        hole = make_source_annotated_object(
-            Hole,
-            SourceExtent(
-                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=2, byteno=1)
-            ),
+        hole_source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=2, byteno=1)
         )
-        self.assertTrue(parse(Peekable(iter([left_paren, right_paren]))).source_extent == hole.source_extent)
+        self.assertTrue(parse(Peekable(iter([left_paren, right_paren]))).source_extent == hole_source_extent)
 
     def test_parenthesized_expression_preserves_source_extent(self) -> None:
         left_paren = LeftParen()
@@ -1275,16 +1266,12 @@ class ParserTests(unittest.TestCase):
         right_paren.source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
         )
-        parenthesized_int_lit = make_source_annotated_object(
-            Int,
-            SourceExtent(
-                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
-            ),
-            1,
+        parenthesized_int_lit_source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
         )
         self.assertTrue(
             parse(Peekable(iter([left_paren, int_lit, right_paren]))).source_extent
-            == parenthesized_int_lit.source_extent
+            == parenthesized_int_lit_source_extent
         )
 
     def test_parse_spread_preserves_source_extent(self) -> None:
@@ -1296,14 +1283,10 @@ class ParserTests(unittest.TestCase):
         name.source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=4, byteno=3), end=SourceLocation(lineno=1, colno=4, byteno=3)
         )
-        spread = make_source_annotated_object(
-            Spread,
-            SourceExtent(
-                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=4, byteno=3)
-            ),
-            "x",
+        spread_source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=4, byteno=3)
         )
-        self.assertTrue(parse(Peekable(iter([ellipsis, name]))).source_extent == spread.source_extent)
+        self.assertTrue(parse(Peekable(iter([ellipsis, name]))).source_extent == spread_source_extent)
 
     def test_parse_binop_preserves_source_extent(self) -> None:
         first_addend = IntLit(1)
@@ -1318,20 +1301,11 @@ class ParserTests(unittest.TestCase):
         second_addend.source_extent = SourceExtent(
             start=SourceLocation(lineno=2, colno=5, byteno=4), end=SourceLocation(lineno=2, colno=5, byteno=4)
         )
-        first_addend_ast = make_source_annotated_object(Int, first_addend.source_extent, 1)
-        operator_ast = BinopKind.ADD
-        second_addend_ast = make_source_annotated_object(Int, second_addend.source_extent, 2)
-        binop = make_source_annotated_object(
-            Binop,
-            SourceExtent(
-                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=2, colno=5, byteno=4)
-            ),
-            operator_ast,
-            first_addend_ast,
-            second_addend_ast,
+        binop_source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=2, colno=5, byteno=4)
         )
         self.assertTrue(
-            parse(Peekable(iter([first_addend, operator, second_addend]))).source_extent == binop.source_extent
+            parse(Peekable(iter([first_addend, operator, second_addend]))).source_extent == binop_source_extent
         )
 
     def test_parse_list_preserves_source_extent(self) -> None:
@@ -1355,18 +1329,11 @@ class ParserTests(unittest.TestCase):
         right_bracket.source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=6, byteno=5), end=SourceLocation(lineno=1, colno=6, byteno=5)
         )
-        one_ast = make_source_annotated_object(Int, one.source_extent, 1)
-        two_ast = make_source_annotated_object(Int, two.source_extent, 2)
-        list_ast = make_source_annotated_object(
-            List,
-            SourceExtent(
-                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=6, byteno=5)
-            ),
-            [one_ast, two_ast],
+        list_source_extent = SourceExtent(
+            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=6, byteno=5)
         )
         self.assertTrue(
-            parse(Peekable(iter([left_bracket, one, comma, two, right_bracket]))).source_extent
-            == list_ast.source_extent
+            parse(Peekable(iter([left_bracket, one, comma, two, right_bracket]))).source_extent == list_source_extent
         )
 
 

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1200,53 +1200,52 @@ class ParserTests(unittest.TestCase):
         self.assertEqual(ast, Apply(Apply(Var("f"), TRUE), FALSE))
 
     def test_parse_int_preserves_source_extent(self) -> None:
-        int_lit = IntLit(1)
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
-        int_lit.source_extent = source_extent
+        int_lit = make_source_annotated_token(IntLit, source_extent, 1)
         self.assertTrue(parse(Peekable(iter([int_lit]))).source_extent == source_extent)
 
     def test_parse_float_preserves_source_extent(self) -> None:
-        float_lit = FloatLit(3.2)
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
         )
-        float_lit.source_extent = source_extent
+        float_lit = make_source_annotated_token(FloatLit, source_extent, 3.2)
         self.assertTrue(parse(Peekable(iter([float_lit]))).source_extent == source_extent)
 
     def test_parse_string_preserves_source_extent(self) -> None:
-        string_lit = StringLit("Hello")
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=7, byteno=6)
         )
-        string_lit.source_extent = source_extent
+        string_lit = make_source_annotated_token(StringLit, source_extent, "Hello")
         self.assertTrue(parse(Peekable(iter([string_lit]))).source_extent == source_extent)
 
     def test_parse_bytes_preserves_source_extent(self) -> None:
-        bytes_lit = BytesLit("QUJD", 64)
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=9, byteno=8)
         )
-        bytes_lit.source_extent = source_extent
+        bytes_lit = make_source_annotated_token(BytesLit, source_extent, "QUJD", 64)
         self.assertTrue(parse(Peekable(iter([bytes_lit]))).source_extent == source_extent)
 
     def test_parse_var_preserves_source_extent(self) -> None:
-        var = Name("x")
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
-        var.source_extent = source_extent
+        var = make_source_annotated_token(Name, source_extent, "x")
         self.assertTrue(parse(Peekable(iter([var]))).source_extent == source_extent)
 
     def test_parse_hole_preserves_source_extent(self) -> None:
-        left_paren = LeftParen()
-        left_paren.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+        left_paren = make_source_annotated_token(
+            LeftParen,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+            ),
         )
-        right_paren = RightParen()
-        right_paren.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
+        right_paren = make_source_annotated_token(
+            RightParen,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
+            ),
         )
         hole_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=2, byteno=1)
@@ -1254,17 +1253,24 @@ class ParserTests(unittest.TestCase):
         self.assertTrue(parse(Peekable(iter([left_paren, right_paren]))).source_extent == hole_source_extent)
 
     def test_parenthesized_expression_preserves_source_extent(self) -> None:
-        left_paren = LeftParen()
-        left_paren.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+        left_paren = make_source_annotated_token(
+            LeftParen,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+            ),
         )
-        int_lit = IntLit(1)
-        int_lit.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
+        int_lit = make_source_annotated_token(
+            IntLit,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
+            ),
+            1,
         )
-        right_paren = RightParen()
-        right_paren.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
+        right_paren = make_source_annotated_token(
+            RightParen,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
+            ),
         )
         parenthesized_int_lit_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
@@ -1275,13 +1281,19 @@ class ParserTests(unittest.TestCase):
         )
 
     def test_parse_spread_preserves_source_extent(self) -> None:
-        ellipsis = Operator("...")
-        ellipsis.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
+        ellipsis = make_source_annotated_token(
+            Operator,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
+            ),
+            "...",
         )
-        name = Name("x")
-        name.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=4, byteno=3), end=SourceLocation(lineno=1, colno=4, byteno=3)
+        name = make_source_annotated_token(
+            Name,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=4, byteno=3), end=SourceLocation(lineno=1, colno=4, byteno=3)
+            ),
+            "x",
         )
         spread_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=4, byteno=3)
@@ -1289,17 +1301,26 @@ class ParserTests(unittest.TestCase):
         self.assertTrue(parse(Peekable(iter([ellipsis, name]))).source_extent == spread_source_extent)
 
     def test_parse_binop_preserves_source_extent(self) -> None:
-        first_addend = IntLit(1)
-        first_addend.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+        first_addend = make_source_annotated_token(
+            IntLit,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+            ),
+            1,
         )
-        operator = Operator("+")
-        operator.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
+        operator = make_source_annotated_token(
+            Operator,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
+            ),
+            "+",
         )
-        second_addend = IntLit(2)
-        second_addend.source_extent = SourceExtent(
-            start=SourceLocation(lineno=2, colno=5, byteno=4), end=SourceLocation(lineno=2, colno=5, byteno=4)
+        second_addend = make_source_annotated_token(
+            IntLit,
+            SourceExtent(
+                start=SourceLocation(lineno=2, colno=5, byteno=4), end=SourceLocation(lineno=2, colno=5, byteno=4)
+            ),
+            2,
         )
         binop_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=2, colno=5, byteno=4)
@@ -1309,25 +1330,38 @@ class ParserTests(unittest.TestCase):
         )
 
     def test_parse_list_preserves_source_extent(self) -> None:
-        left_bracket = LeftBracket()
-        left_bracket.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+        left_bracket = make_source_annotated_token(
+            LeftBracket,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
+            ),
         )
-        one = IntLit(1)
-        one.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
+        one = make_source_annotated_token(
+            IntLit,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=2, byteno=1), end=SourceLocation(lineno=1, colno=2, byteno=1)
+            ),
+            1,
         )
-        comma = Operator(",")
-        comma.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
+        comma = make_source_annotated_token(
+            Operator,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=3, byteno=2), end=SourceLocation(lineno=1, colno=3, byteno=2)
+            ),
+            ",",
         )
-        two = IntLit(2)
-        two.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=5, byteno=4), end=SourceLocation(lineno=1, colno=5, byteno=4)
+        two = make_source_annotated_token(
+            IntLit,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=5, byteno=4), end=SourceLocation(lineno=1, colno=5, byteno=4)
+            ),
+            2,
         )
-        right_bracket = RightBracket()
-        right_bracket.source_extent = SourceExtent(
-            start=SourceLocation(lineno=1, colno=6, byteno=5), end=SourceLocation(lineno=1, colno=6, byteno=5)
+        right_bracket = make_source_annotated_token(
+            RightBracket,
+            SourceExtent(
+                start=SourceLocation(lineno=1, colno=6, byteno=5), end=SourceLocation(lineno=1, colno=6, byteno=5)
+            ),
         )
         list_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=6, byteno=5)

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1204,35 +1204,35 @@ class ParserTests(unittest.TestCase):
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
         int_lit = make_source_annotated_token(IntLit, source_extent, 1)
-        self.assertTrue(parse(Peekable(iter([int_lit]))).source_extent == source_extent)
+        self.assertEqual(parse(Peekable(iter([int_lit]))).source_extent, source_extent)
 
     def test_parse_float_preserves_source_extent(self) -> None:
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
         )
         float_lit = make_source_annotated_token(FloatLit, source_extent, 3.2)
-        self.assertTrue(parse(Peekable(iter([float_lit]))).source_extent == source_extent)
+        self.assertEqual(parse(Peekable(iter([float_lit]))).source_extent, source_extent)
 
     def test_parse_string_preserves_source_extent(self) -> None:
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=7, byteno=6)
         )
         string_lit = make_source_annotated_token(StringLit, source_extent, "Hello")
-        self.assertTrue(parse(Peekable(iter([string_lit]))).source_extent == source_extent)
+        self.assertEqual(parse(Peekable(iter([string_lit]))).source_extent, source_extent)
 
     def test_parse_bytes_preserves_source_extent(self) -> None:
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=9, byteno=8)
         )
         bytes_lit = make_source_annotated_token(BytesLit, source_extent, "QUJD", 64)
-        self.assertTrue(parse(Peekable(iter([bytes_lit]))).source_extent == source_extent)
+        self.assertEqual(parse(Peekable(iter([bytes_lit]))).source_extent, source_extent)
 
     def test_parse_var_preserves_source_extent(self) -> None:
         source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=1, byteno=0)
         )
         var = make_source_annotated_token(Name, source_extent, "x")
-        self.assertTrue(parse(Peekable(iter([var]))).source_extent == source_extent)
+        self.assertEqual(parse(Peekable(iter([var]))).source_extent, source_extent)
 
     def test_parse_hole_preserves_source_extent(self) -> None:
         left_paren = make_source_annotated_token(
@@ -1250,7 +1250,7 @@ class ParserTests(unittest.TestCase):
         hole_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=2, byteno=1)
         )
-        self.assertTrue(parse(Peekable(iter([left_paren, right_paren]))).source_extent == hole_source_extent)
+        self.assertEqual(parse(Peekable(iter([left_paren, right_paren]))).source_extent, hole_source_extent)
 
     def test_parenthesized_expression_preserves_source_extent(self) -> None:
         left_paren = make_source_annotated_token(
@@ -1275,9 +1275,8 @@ class ParserTests(unittest.TestCase):
         parenthesized_int_lit_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=3, byteno=2)
         )
-        self.assertTrue(
-            parse(Peekable(iter([left_paren, int_lit, right_paren]))).source_extent
-            == parenthesized_int_lit_source_extent
+        self.assertEqual(
+            parse(Peekable(iter([left_paren, int_lit, right_paren]))).source_extent, parenthesized_int_lit_source_extent
         )
 
     def test_parse_spread_preserves_source_extent(self) -> None:
@@ -1298,7 +1297,7 @@ class ParserTests(unittest.TestCase):
         spread_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=4, byteno=3)
         )
-        self.assertTrue(parse(Peekable(iter([ellipsis, name]))).source_extent == spread_source_extent)
+        self.assertEqual(parse(Peekable(iter([ellipsis, name]))).source_extent, spread_source_extent)
 
     def test_parse_binop_preserves_source_extent(self) -> None:
         first_addend = make_source_annotated_token(
@@ -1325,8 +1324,8 @@ class ParserTests(unittest.TestCase):
         binop_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=2, colno=5, byteno=4)
         )
-        self.assertTrue(
-            parse(Peekable(iter([first_addend, operator, second_addend]))).source_extent == binop_source_extent
+        self.assertEqual(
+            parse(Peekable(iter([first_addend, operator, second_addend]))).source_extent, binop_source_extent
         )
 
     def test_parse_list_preserves_source_extent(self) -> None:
@@ -1366,8 +1365,8 @@ class ParserTests(unittest.TestCase):
         list_source_extent = SourceExtent(
             start=SourceLocation(lineno=1, colno=1, byteno=0), end=SourceLocation(lineno=1, colno=6, byteno=5)
         )
-        self.assertTrue(
-            parse(Peekable(iter([left_bracket, one, comma, two, right_bracket]))).source_extent == list_source_extent
+        self.assertEqual(
+            parse(Peekable(iter([left_bracket, one, comma, two, right_bracket]))).source_extent, list_source_extent
         )
 
 
@@ -2621,7 +2620,7 @@ class EndToEndTests(EndToEndTestsBase):
             match_function_three_source_extent,
         ]
 
-        self.assertTrue(outer_function.source_extent == outer_function_source_extent)
+        self.assertEqual(outer_function.source_extent, outer_function_source_extent)
         self.assertTrue(
             all(
                 match_function.source_extent == source_extent
@@ -2673,9 +2672,9 @@ class EndToEndTests(EndToEndTestsBase):
             start=SourceLocation(lineno=4, colno=34, byteno=84), end=SourceLocation(lineno=5, colno=79, byteno=205)
         )
 
-        self.assertTrue(outer_function.source_extent == outer_function_source_extent)
-        self.assertTrue(arg.source_extent == arg_source_extent)
-        self.assertTrue(func.source_extent == func_source_extent)
+        self.assertEqual(outer_function.source_extent, outer_function_source_extent)
+        self.assertEqual(arg.source_extent, arg_source_extent)
+        self.assertEqual(func.source_extent, func_source_extent)
 
 
 class ClosureOptimizeTests(unittest.TestCase):


### PR DESCRIPTION
I added a function called `make_source_annotated_token` to simplify the repeated logic in the source extent tests, but if it's unnecessary I can easily revert those commits.

Edit: Linking the PR for easy, future reference: #241.