### PR TITLE
Scrapyard server

### DIFF
--- a/scrapscript.py
+++ b/scrapscript.py
@@ -2482,6 +2482,64 @@ def flat_command(args: argparse.Namespace) -> None:
     sys.stdout.buffer.write(serializer.output)
 
 
+def server_command(args: argparse.Namespace) -> None:
+    import http.server
+    import socketserver
+    import hashlib
+    import os.path
+
+    dir = os.path.abspath(args.directory)
+    if not os.path.isdir(dir):
+        print(f"Error: {dir} is not a valid directory")
+        sys.exit(1)
+
+    scraps = {}
+    for root, _, files in os.walk(dir):
+        for file in files:
+            if file.endswith(".scrap"):
+                file_path = os.path.join(root, file)
+                rel_path = os.path.relpath(file_path, dir)
+                rel_path_without_ext = os.path.splitext(rel_path)[0]
+                with open(file_path, "r") as f:
+                    try:
+                        program = parse(tokenize(f.read()))
+                        serializer = Serializer()
+                        serializer.serialize(program)
+                        serialized = bytes(serializer.output)
+                        scraps[rel_path_without_ext] = serialized
+                        logger.debug(f"Loaded {rel_path_without_ext}")
+                        file_hash = hashlib.md5(serialized).hexdigest()
+                        scraps[f"${file_hash}"] = serialized
+                        logger.debug(f"Loaded {rel_path_without_ext} as ${file_hash}")
+                    except Exception as e:
+                        logger.error(f"Error processing {file_path}: {e}")
+
+    class ScrapHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+        def do_GET(self) -> None:
+            path = self.path.lstrip("/")
+            if path in scraps:
+                self.send_response(200)
+                self.send_header("Content-Type", "application/scrap; charset=binary")
+                self.send_header("Content-Disposition", f'attachment; filename="{path}.scrap"')
+                self.send_header("Content-Length", str(len(scraps[path])))
+                self.end_headers()
+                self.wfile.write(scraps[path])
+            else:
+                self.send_response(404)
+                self.send_header("Content-Type", "text/plain")
+                self.end_headers()
+                self.wfile.write(b"File not found")
+
+    os.chdir(dir)
+    handler = ScrapHTTPRequestHandler
+    with socketserver.TCPServer((args.host, args.port), handler) as httpd:
+        logger.info(f"Serving {dir} at http://{args.host}:{args.port}")
+        try:
+            httpd.serve_forever()
+        except KeyboardInterrupt:
+            httpd.server_close()
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(prog="scrapscript")
     subparsers = parser.add_subparsers(dest="command")
@@ -2520,6 +2578,16 @@ def main() -> None:
 
     flat = subparsers.add_parser("flat")
     flat.set_defaults(func=flat_command)
+
+    yard = subparsers.add_parser("yard")
+    yard_subparsers = yard.add_subparsers(dest="yard_command")
+
+    yard_server = yard_subparsers.add_parser("server")
+    yard_server.set_defaults(func=server_command)
+    yard_server.add_argument("directory", type=str, help="Directory to serve")
+    yard_server.add_argument("--host", type=str, default="127.0.0.1", help="Host to bind to")
+    yard_server.add_argument("--port", type=int, default=8080, help="Port to listen on")
+    yard_server.add_argument("--debug", action="store_true")
 
     args = parser.parse_args()
     if not args.command:

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -2594,7 +2594,7 @@ def main() -> None:
 
     yard_server = yard_subparsers.add_parser("server")
     yard_server.set_defaults(func=server_command)
-    yard_server.add_argument("directory", type=str, default=".", help="Directory to serve")
+    yard_server.add_argument("directory", type=str, nargs="?", default=".", help="Directory to serve")
     yard_server.add_argument("--host", type=str, default="127.0.0.1", help="Host to bind to")
     yard_server.add_argument("--port", type=int, default=8080, help="Port to listen on")
 

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -2486,7 +2486,6 @@ def server_command(args: argparse.Namespace) -> None:
     import http.server
     import socketserver
     import hashlib
-    import os.path
 
     dir = os.path.abspath(args.directory)
     if not os.path.isdir(dir):

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -2486,6 +2486,7 @@ def server_command(args: argparse.Namespace) -> None:
     import http.server
     import socketserver
     import hashlib
+    import re
 
     dir = os.path.abspath(args.directory)
     if not os.path.isdir(dir):
@@ -2495,7 +2496,7 @@ def server_command(args: argparse.Namespace) -> None:
     scraps = {}
     for root, _, files in os.walk(dir):
         for file in files:
-            if file.endswith(".scrap"):
+            if re.match(r"^[a-zA-Z0-9-]+\.scrap$", file):
                 file_path = os.path.join(root, file)
                 rel_path = os.path.relpath(file_path, dir)
                 rel_path_without_ext = os.path.splitext(rel_path)[0]
@@ -2520,7 +2521,7 @@ def server_command(args: argparse.Namespace) -> None:
             if scrap is not None:
                 self.send_response(200)
                 self.send_header("Content-Type", "application/scrap; charset=binary")
-                self.send_header("Content-Disposition", f'attachment; filename="{path}.scrap"')
+                self.send_header("Content-Disposition", f'attachment; filename={json.dumps(f"{path}.scrap")}')
                 self.send_header("Content-Length", str(len(scrap)))
                 self.end_headers()
                 self.wfile.write(scrap)
@@ -2584,7 +2585,7 @@ def main() -> None:
 
     yard_server = yard_subparsers.add_parser("server")
     yard_server.set_defaults(func=server_command)
-    yard_server.add_argument("directory", type=str, help="Directory to serve")
+    yard_server.add_argument("directory", type=str, default=".", help="Directory to serve")
     yard_server.add_argument("--host", type=str, default="127.0.0.1", help="Host to bind to")
     yard_server.add_argument("--port", type=int, default=8080, help="Port to listen on")
     yard_server.add_argument("--debug", action="store_true")

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -2515,7 +2515,16 @@ def server_command(args: argparse.Namespace) -> None:
                 except Exception as e:
                     logger.error(f"Error processing {file_path}: {e}")
 
+    keep_serving = True
+
     class ScrapHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
+        def do_QUIT(self) -> None:
+            self.send_response(200)
+            self.end_headers()
+            self.wfile.write(b"Quitting")
+            nonlocal keep_serving
+            keep_serving = False
+
         def do_GET(self) -> None:
             path = self.path.lstrip("/")
             scrap = scraps.get(path)
@@ -2536,10 +2545,8 @@ def server_command(args: argparse.Namespace) -> None:
     handler = ScrapHTTPRequestHandler
     with socketserver.TCPServer((args.host, args.port), handler) as httpd:
         logger.info(f"Serving {dir} at http://{args.host}:{args.port}")
-        try:
-            httpd.serve_forever()
-        except KeyboardInterrupt:
-            httpd.server_close()
+        while keep_serving:
+            httpd.handle_request()
 
 
 def main() -> None:

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -2541,7 +2541,6 @@ def server_command(args: argparse.Namespace) -> None:
                 self.end_headers()
                 self.wfile.write(b"File not found")
 
-    os.chdir(dir)
     handler = ScrapHTTPRequestHandler
     with socketserver.TCPServer((args.host, args.port), handler) as httpd:
         logger.info(f"Serving {dir} at http://{args.host}:{args.port}")

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -2509,7 +2509,7 @@ def server_command(args: argparse.Namespace) -> None:
                     serialized = bytes(serializer.output)
                     scraps[rel_path_without_ext] = serialized
                     logger.debug(f"Loaded {rel_path_without_ext}")
-                    file_hash = hashlib.md5(serialized).hexdigest()
+                    file_hash = hashlib.sha256(serialized).hexdigest()
                     scraps[f"${file_hash}"] = serialized
                     logger.debug(f"Loaded {rel_path_without_ext} as ${file_hash}")
                 except Exception as e:

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -2486,7 +2486,6 @@ def server_command(args: argparse.Namespace) -> None:
     import http.server
     import socketserver
     import hashlib
-    import re
 
     dir = os.path.abspath(args.directory)
     if not os.path.isdir(dir):
@@ -2496,23 +2495,25 @@ def server_command(args: argparse.Namespace) -> None:
     scraps = {}
     for root, _, files in os.walk(dir):
         for file in files:
-            if re.match(r"^[a-zA-Z0-9-]+\.scrap$", file):
-                file_path = os.path.join(root, file)
-                rel_path = os.path.relpath(file_path, dir)
-                rel_path_without_ext = os.path.splitext(rel_path)[0]
-                with open(file_path, "r") as f:
-                    try:
-                        program = parse(tokenize(f.read()))
-                        serializer = Serializer()
-                        serializer.serialize(program)
-                        serialized = bytes(serializer.output)
-                        scraps[rel_path_without_ext] = serialized
-                        logger.debug(f"Loaded {rel_path_without_ext}")
-                        file_hash = hashlib.md5(serialized).hexdigest()
-                        scraps[f"${file_hash}"] = serialized
-                        logger.debug(f"Loaded {rel_path_without_ext} as ${file_hash}")
-                    except Exception as e:
-                        logger.error(f"Error processing {file_path}: {e}")
+            file_path = os.path.join(root, file)
+            rel_path = os.path.relpath(file_path, dir)
+            if file.startswith("$"):
+                logger.debug(f"Skipping {rel_path}")
+                continue
+            rel_path_without_ext = os.path.splitext(rel_path)[0]
+            with open(file_path, "r") as f:
+                try:
+                    program = parse(tokenize(f.read()))
+                    serializer = Serializer()
+                    serializer.serialize(program)
+                    serialized = bytes(serializer.output)
+                    scraps[rel_path_without_ext] = serialized
+                    logger.debug(f"Loaded {rel_path_without_ext}")
+                    file_hash = hashlib.md5(serialized).hexdigest()
+                    scraps[f"${file_hash}"] = serialized
+                    logger.debug(f"Loaded {rel_path_without_ext} as ${file_hash}")
+                except Exception as e:
+                    logger.error(f"Error processing {file_path}: {e}")
 
     class ScrapHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         def do_GET(self) -> None:

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -2589,6 +2589,7 @@ def main() -> None:
     flat.set_defaults(func=flat_command)
 
     yard = subparsers.add_parser("yard")
+    yard.set_defaults(func=lambda _: yard.print_help())
     yard_subparsers = yard.add_subparsers(dest="yard_command")
 
     yard_server = yard_subparsers.add_parser("server")

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -2588,7 +2588,6 @@ def main() -> None:
     yard_server.add_argument("directory", type=str, default=".", help="Directory to serve")
     yard_server.add_argument("--host", type=str, default="127.0.0.1", help="Host to bind to")
     yard_server.add_argument("--port", type=int, default=8080, help="Port to listen on")
-    yard_server.add_argument("--debug", action="store_true")
 
     args = parser.parse_args()
     if not args.command:

--- a/scrapscript.py
+++ b/scrapscript.py
@@ -2516,13 +2516,14 @@ def server_command(args: argparse.Namespace) -> None:
     class ScrapHTTPRequestHandler(http.server.SimpleHTTPRequestHandler):
         def do_GET(self) -> None:
             path = self.path.lstrip("/")
-            if path in scraps:
+            scrap = scraps.get(path)
+            if scrap is not None:
                 self.send_response(200)
                 self.send_header("Content-Type", "application/scrap; charset=binary")
                 self.send_header("Content-Disposition", f'attachment; filename="{path}.scrap"')
-                self.send_header("Content-Length", str(len(scraps[path])))
+                self.send_header("Content-Length", str(len(scrap)))
                 self.end_headers()
-                self.wfile.write(scraps[path])
+                self.wfile.write(scrap)
             else:
                 self.send_response(404)
                 self.send_header("Content-Type", "text/plain")

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -4081,7 +4081,7 @@ class ServerCommandTests(unittest.TestCase):
             try:
                 with socket.create_connection((self.host, self.port), timeout=0.1) as s:
                     break
-            except Exception:
+            except (ConnectionRefusedError, socket.timeout):
                 time.sleep(0.01)
 
     def test_server_serves_scrap_by_path(self) -> None:

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -1,6 +1,7 @@
 import unittest
 import re
 from typing import Optional
+import urllib.request
 
 # ruff: noqa: F405
 # ruff: noqa: F403
@@ -4052,10 +4053,12 @@ class PrettyPrintTests(unittest.TestCase):
 
 
 class ServerCommandTests(unittest.TestCase):
-    import urllib.request
-
     def setUp(self) -> None:
-        import threading, time, os, socket, argparse
+        import threading
+        import time
+        import os
+        import socket
+        import argparse
         from scrapscript import server_command
 
         # Find a random available port
@@ -4076,7 +4079,7 @@ class ServerCommandTests(unittest.TestCase):
         # Wait for the server to start
         while True:
             try:
-                with socket.create_connection((self.host, self.port), timeout=0.1) as s: 
+                with socket.create_connection((self.host, self.port), timeout=0.1) as s:
                     break
             except Exception:
                 time.sleep(0.01)

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -4052,6 +4052,8 @@ class PrettyPrintTests(unittest.TestCase):
 
 
 class ServerCommandTests(unittest.TestCase):
+    import urllib.request
+
     def setUp(self) -> None:
         import threading, time, os, socket, argparse
         from scrapscript import server_command
@@ -4059,11 +4061,11 @@ class ServerCommandTests(unittest.TestCase):
         # Find a random available port
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("127.0.0.1", 0))
-            self.port = s.getsockname()[1]
+            self.host, self.port = s.getsockname()
 
         args = argparse.Namespace(
             directory=os.path.abspath(os.path.join(os.path.dirname(__file__), "examples")),
-            host="127.0.0.1",
+            host=self.host,
             port=self.port,
         )
 
@@ -4071,25 +4073,25 @@ class ServerCommandTests(unittest.TestCase):
         self.server_thread.daemon = True
         self.server_thread.start()
 
-        time.sleep(0.1)
+        # Wait for the server to start
+        while True:
+            try:
+                with socket.create_connection((self.host, self.port), timeout=0.1) as s: 
+                    break
+            except Exception:
+                time.sleep(0.01)
 
     def test_server_serves_scrap_by_path(self) -> None:
-        import urllib.request
-
-        response = urllib.request.urlopen(f"http://localhost:{self.port}/0_home/factorial")
+        response = urllib.request.urlopen(f"http://{self.host}:{self.port}/0_home/factorial")
         self.assertEqual(response.status, 200)
 
     def test_server_serves_scrap_by_hash(self) -> None:
-        import urllib.request
-
-        response = urllib.request.urlopen(f"http://localhost:{self.port}/$781cdc5a4f9855a2a60321d2eea56685")
+        response = urllib.request.urlopen(f"http://{self.host}:{self.port}/$781cdc5a4f9855a2a60321d2eea56685")
         self.assertEqual(response.status, 200)
 
     def test_server_fails_missing_scrap(self) -> None:
-        import urllib.request
-
         with self.assertRaises(urllib.error.HTTPError) as cm:
-            urllib.request.urlopen(f"http://localhost:{self.port}/foo")
+            urllib.request.urlopen(f"http://{self.host}:{self.port}/foo")
         self.assertEqual(cm.exception.code, 404)
 
 

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -4067,7 +4067,7 @@ class ServerCommandTests(unittest.TestCase):
             self.host, self.port = s.getsockname()
 
         args = argparse.Namespace(
-            directory=os.path.abspath(os.path.join(os.path.dirname(__file__), "examples")),
+            directory=os.path.join(os.path.dirname(__file__), "examples"),
             host=self.host,
             port=self.port,
         )

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -4093,7 +4093,7 @@ class ServerCommandTests(unittest.TestCase):
         self.assertEqual(response.status, 200)
 
     def test_server_serves_scrap_by_hash(self) -> None:
-        response = urllib.request.urlopen(f"http://{self.host}:{self.port}/$781cdc5a4f9855a2a60321d2eea56685")
+        response = urllib.request.urlopen(f"http://{self.host}:{self.port}/$09242a8dfec0ed32eb9ddd5452f0082998712d35306fec2042bad8ac5b6e9580")
         self.assertEqual(response.status, 200)
 
     def test_server_fails_missing_scrap(self) -> None:

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -4084,6 +4084,10 @@ class ServerCommandTests(unittest.TestCase):
             except (ConnectionRefusedError, socket.timeout):
                 time.sleep(0.01)
 
+    def tearDown(self) -> None:
+        quit_request = urllib.request.Request(f"http://{self.host}:{self.port}/", method="QUIT")
+        urllib.request.urlopen(quit_request)
+
     def test_server_serves_scrap_by_path(self) -> None:
         response = urllib.request.urlopen(f"http://{self.host}:{self.port}/0_home/factorial")
         self.assertEqual(response.status, 200)

--- a/scrapscript_tests.py
+++ b/scrapscript_tests.py
@@ -4051,5 +4051,47 @@ class PrettyPrintTests(unittest.TestCase):
         self.assertEqual(pretty(obj), "#x (a -> b)")
 
 
+class ServerCommandTests(unittest.TestCase):
+    def setUp(self) -> None:
+        import threading, time, os, socket, argparse
+        from scrapscript import server_command
+
+        # Find a random available port
+        with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+            s.bind(("127.0.0.1", 0))
+            self.port = s.getsockname()[1]
+
+        args = argparse.Namespace(
+            directory=os.path.abspath(os.path.join(os.path.dirname(__file__), "examples")),
+            host="127.0.0.1",
+            port=self.port,
+        )
+
+        self.server_thread = threading.Thread(target=server_command, args=(args,))
+        self.server_thread.daemon = True
+        self.server_thread.start()
+
+        time.sleep(0.1)
+
+    def test_server_serves_scrap_by_path(self) -> None:
+        import urllib.request
+
+        response = urllib.request.urlopen(f"http://localhost:{self.port}/0_home/factorial")
+        self.assertEqual(response.status, 200)
+
+    def test_server_serves_scrap_by_hash(self) -> None:
+        import urllib.request
+
+        response = urllib.request.urlopen(f"http://localhost:{self.port}/$781cdc5a4f9855a2a60321d2eea56685")
+        self.assertEqual(response.status, 200)
+
+    def test_server_fails_missing_scrap(self) -> None:
+        import urllib.request
+
+        with self.assertRaises(urllib.error.HTTPError) as cm:
+            urllib.request.urlopen(f"http://localhost:{self.port}/foo")
+        self.assertEqual(cm.exception.code, 404)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Implemented a new `server_command` function to serve `.scrap` files over HTTP, allowing retrieval by path or hash. Added error handling for missing files. Included unit tests for server functionality in `scrapscript_tests.py` to ensure proper operation and error responses.